### PR TITLE
Preprocessing and Train Pipeline fixes

### DIFF
--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -148,6 +148,8 @@ void AssimpLoaderPlugin::run() {
 	//ToDo Move Processing
 	QStringList files = loadFilesFromDir();
 
+	// Reset the sequence counter for each run
+	sequenceCounter = 1;
 	for (auto file : files) {
 		//QString file_name = QFileDialog::getOpenFileName(nullptr, "Import Animation", "C://", "(*.bvh *.fbx)");
 

--- a/python/notebooks/LocalAutoPipeline.py
+++ b/python/notebooks/LocalAutoPipeline.py
@@ -21,8 +21,8 @@ from MotionPreprocessing import MotionProcessor, count_lines, read_csv_data, Rea
 
 def main():
     # common config
-    dataset_path = r"C:\DEV\DATASETS\Survivor_Gen"
-    path_to_ai4anim = r"C:\DEV\AI4Animation\AI4Animation\SIGGRAPH_2022\PyTorch"
+    dataset_path = r"C:\anim-ws\Handover_AnimHost\Handover AnimHost Implementation\DEMO_Package\DEMO_Package\datasets\Survivor_Gen"
+    path_to_ai4anim = r"C:\anim-ws\Handover_AnimHost\Handover AnimHost Implementation\AI4Animation_Siggraph2022_Starke\PyTorch"
     mp = MotionProcessor(dataset_path, path_to_ai4anim)   
     # count number of velcocity samples
     num_samples_total = count_lines(dataset_path + "/sequences_velocity.txt")
@@ -48,9 +48,13 @@ def main():
     #buttered = scipy.signal.filtfilt(b, a, sequence["out_jvel_y_hand_L"]) 
     result_sequences = []
 
-    for n in range(num_sequences):
+    # Get the actual unique sequence IDs instead of assuming 1-40
+    unique_seq_ids = df_velocities.index.get_level_values('SeqId').unique()
+    print(f"Actual sequence IDs: {unique_seq_ids[:10]}...")  # Debug: show first 10
+
+    for seq_id in unique_seq_ids:
         #select sequence by index
-        sequence = df_velocities.xs(key=n+1, level="SeqId")
+        sequence = df_velocities.xs(key=seq_id, level="SeqId")
         butterw_combined = []
         #apply butterworth to every column
         for col in range(num_features_velocity):

--- a/python/notebooks/LocalAutoPipeline.py
+++ b/python/notebooks/LocalAutoPipeline.py
@@ -21,8 +21,8 @@ from MotionPreprocessing import MotionProcessor, count_lines, read_csv_data, Rea
 
 def main():
     # common config
-    dataset_path = r"C:\anim-ws\Handover_AnimHost\Handover AnimHost Implementation\DEMO_Package\DEMO_Package\datasets\Survivor_Gen"
-    path_to_ai4anim = r"C:\anim-ws\Handover_AnimHost\Handover AnimHost Implementation\AI4Animation_Siggraph2022_Starke\PyTorch"
+    dataset_path = r"C:\DEV\DATASETS\Survivor_Gen"
+    path_to_ai4anim = r"C:\DEV\AI4Animation\AI4Animation\SIGGRAPH_2022\PyTorch"
     mp = MotionProcessor(dataset_path, path_to_ai4anim)   
     # count number of velcocity samples
     num_samples_total = count_lines(dataset_path + "/sequences_velocity.txt")
@@ -38,8 +38,8 @@ def main():
     df_velocities = pd.concat([velocity_ids, df_velocities], axis=1)
     df_velocities.set_index(["SeqId","Frame"],inplace = True)
 
-    num_sequences = df_velocities.index.get_level_values('SeqId').nunique()
-    print(num_sequences)
+    unique_seq_ids = df_velocities.index.get_level_values('SeqId').unique()
+    print(f"Applying Butterworth filter to {len(unique_seq_ids)} sequences. First sequence ID: {unique_seq_ids[0]}.")
     #prepare filter
     fc = 4.5
     w = fc / (60/2) 
@@ -47,10 +47,6 @@ def main():
     b, a = scipy.signal.butter(5, w, 'low')
     #buttered = scipy.signal.filtfilt(b, a, sequence["out_jvel_y_hand_L"]) 
     result_sequences = []
-
-    # Get the actual unique sequence IDs instead of assuming 1-40
-    unique_seq_ids = df_velocities.index.get_level_values('SeqId').unique()
-    print(f"Actual sequence IDs: {unique_seq_ids[:10]}...")  # Debug: show first 10
 
     for seq_id in unique_seq_ids:
         #select sequence by index

--- a/python/notebooks/MotionPreprocessing.py
+++ b/python/notebooks/MotionPreprocessing.py
@@ -6,7 +6,7 @@ import plotly.express as px
 import plotly.graph_objects as go
 import math
 import time
-
+import os
 
 class FrameRange:
     def __init__(self, num_samples, fps, reference_frame, start_index):
@@ -273,7 +273,7 @@ class MotionProcessor:
 
         df_phaseData = pd.DataFrame(phaseData, columns=phaseData_header)
         cols = [f"PhaseValue{i+1}" for i in range(self.num_phase_channel)]
-        df_phaseData[cols] = df_phaseData[cols].map(lambda t: repeat(t, 1.0))
+        df_phaseData[cols] = df_phaseData[cols].apply(lambda t: repeat(t, 1.0))
         df_phaseData = pd.concat([phaseSequence, df_phaseData], axis=1)
 
         ## Generate Cloumn names for phase values
@@ -385,6 +385,14 @@ class MotionProcessor:
         return self.OutputData
     
     def export_data(self, folder_path= "../data/"):
+        # Create directory if it doesn't exist
+        os.makedirs(folder_path, exist_ok=True)
+
+        # Check if Input.bin already exists
+        input_bin_path = os.path.join(folder_path, 'Input.bin')
+        if os.path.exists(input_bin_path):
+            print(f"Warning: {input_bin_path} already exists and will be overwritten.")
+
         # Export input data
         print("Exporting data...")
         in_dropped = self.InputData.drop(["Type", "File","SeqUUID"], axis=1)

--- a/python/notebooks/MotionPreprocessing.py
+++ b/python/notebooks/MotionPreprocessing.py
@@ -388,11 +388,6 @@ class MotionProcessor:
         # Create directory if it doesn't exist
         os.makedirs(folder_path, exist_ok=True)
 
-        # Check if Input.bin already exists
-        input_bin_path = os.path.join(folder_path, 'Input.bin')
-        if os.path.exists(input_bin_path):
-            print(f"Warning: {input_bin_path} already exists and will be overwritten.")
-
         # Export input data
         print("Exporting data...")
         in_dropped = self.InputData.drop(["Type", "File","SeqUUID"], axis=1)

--- a/python/notebooks/MotionPreprocessing.py
+++ b/python/notebooks/MotionPreprocessing.py
@@ -237,7 +237,7 @@ class MotionProcessor:
         
         self.dataset_path = dataset_path
         self.trained_phase_param_file =  ai4animation_path + r"\PAE\Training\Parameters_30.txt"
-        self.trained_phase_sequence_file = r"\PAE\Dataset\Sequences.txt"
+        self.trained_phase_sequence_file = ai4animation_path + r"\PAE\Dataset\Sequences.txt"
         
         self.input_feature_count, self.output_feature_count = parse_input_output_features(dataset_path + "/metadata.txt")
 


### PR DESCRIPTION
# Description
* Setting AssimLoaderPlugin sequence output ids to 1 at the start of each run in case of multiple runs in one Scene. LocalAutoPipeline also doesn't assum start with 1.
* MotionProcessor creates the data dir for first time users
* 2 minor MotionProcessor bugs

# Testing
* Ran the `Preprocessing.flow` on non-mirrored 2025 MAX-R SURVIVOR data and confirmed equal file size to output documentation (145,836 KB data_X.bin file, 29,677 KB joint_velocity.bin)
* Deleted the output data, reran `Preprocessing.flow` and confirmed `sequences_velocity` ids still start with 1
* Ran LocalAutoPipeline on 3 PAE, 5 GNN epochs