### PR TITLE
AnimHost Training Pipeline - Phase 4: Expose more PAE, GNN hyperparameters

### DIFF
--- a/AnimHost/animHost_Plugins/TrainingPlugin/Training/ConfigWidget.h
+++ b/AnimHost/animHost_Plugins/TrainingPlugin/Training/ConfigWidget.h
@@ -125,8 +125,8 @@ private:
 
     QWidget* createPathWidget(const QString& displayName);
     QWidget* createLineEditWidget(const QString& displayName);
+    QWidget* createDoubleLineEditWidget(const QString& displayName);
     QWidget* createSpinBoxWidget(const QString& displayName);
-    QWidget* createDoubleSpinBoxWidget(const QString& displayName);
     QWidget* createCheckBoxWidget(const QString& displayName);
 
     // Widget update methods

--- a/AnimHost/animHost_Plugins/TrainingPlugin/Training/MLFrameworkTypes.h
+++ b/AnimHost/animHost_Plugins/TrainingPlugin/Training/MLFrameworkTypes.h
@@ -72,17 +72,20 @@ struct StarkeConfig {
     QString dataset_path = QDir::cleanPath(QDir(QCoreApplication::applicationDirPath()).filePath("../Survivor_Training_Data"));
     QString path_to_ai4anim = QDir::cleanPath(QDir(QCoreApplication::applicationDirPath()).filePath("../AI4Animation-master"));
     int pae_epochs = 30;
+    double pae_learning_rate = 1e-4;
     int gnn_epochs = 300;
+    double gnn_learning_rate = 1e-4;
+    double gnn_dropout = 0.3;
 
-    auto tie() const { return std::tie(dataset_path, path_to_ai4anim, pae_epochs, gnn_epochs); }
-    auto tie()       { return std::tie(dataset_path, path_to_ai4anim, pae_epochs, gnn_epochs); }
+    auto tie() const { return std::tie(dataset_path, path_to_ai4anim, pae_epochs, pae_learning_rate, gnn_epochs, gnn_learning_rate, gnn_dropout); }
+    auto tie()       { return std::tie(dataset_path, path_to_ai4anim, pae_epochs, pae_learning_rate, gnn_epochs, gnn_learning_rate, gnn_dropout); }
 
     static constexpr auto field_names() {
-        return std::array{"dataset_path", "path_to_ai4anim", "pae_epochs", "gnn_epochs"};
+        return std::array{"dataset_path", "path_to_ai4anim", "pae_epochs", "pae_learning_rate", "gnn_epochs", "gnn_learning_rate", "gnn_dropout"};
     }
 
     static constexpr auto display_names() {
-        return std::array{"Dataset Path", "AI4Animation Path", "PAE Epochs", "GNN Epochs"};
+        return std::array{"Dataset Path", "AI4Animation Path", "PAE Epochs", "PAE Learning Rate", "GNN Epochs", "GNN Learning Rate", "GNN Dropout"};
     }
 
     QJsonObject toJson() const {

--- a/TRAINING.md
+++ b/TRAINING.md
@@ -58,7 +58,6 @@ C:/My-AnimHost-Run/
 ...
 └── Survivor_Training_Data/
 ```
-**NOTE:** Clear this dir if you already have it, there is a bug that blocks overwriting of some files.
 
 2. Launch `AnimHost.exe` from the release package
 

--- a/python/ml_framework/DEV_GUIDE.md
+++ b/python/ml_framework/DEV_GUIDE.md
@@ -155,3 +155,18 @@ The `line_parser` function converts script-specific output formats into standard
 - Parses "Progress 23.42 %" → `tracker.log_percentage_progress("Controller training", 23.42)`
 
 This architecture allows integration of any external training script by providing an appropriate line parser that translates its output format into the standard JSON protocol.
+
+## Exposing External Script Parameters to AnimHost
+
+To add new training hyperparameters to the AnimHost UI, synchronize changes across four locations:
+
+1. **`AnimHost/animHost_Plugins/TrainingPlugin/Training/MLFrameworkTypes.h`** - Add field to your config struct and update `tie()`, `field_names()`, and `display_names()` arrays
+2. **`python/ml_framework/config/model_configs.py`** - Add matching field to your config dataclass with validation in `validate()`
+3. **`python/ml_framework/external/starke_training.py`** - Use config values to update external training scripts via `write_script_variables()`
+4. **`python/ml_framework/starke_model_config.json`** - Add default values for example configurations
+
+**UI widgets are auto-generated** by `ConfigWidget.h` based on field type: `int` → spinbox, `double` → validated text field (scientific notation supported), `QString` → text/path field, `bool` → checkbox.
+
+**Key requirements**: Field types must match between C++ and Python (`double` ↔ `float`, `int` ↔ `int`), field order in `tie()` must match metadata arrays, and changes require rebuilding AnimHost.
+
+**Example**: See [PR #53](https://github.com/FilmakademieRnd/AnimHost/pull/53) for an implementation adding learning rate and dropout parameters.

--- a/python/ml_framework/config/model_configs.py
+++ b/python/ml_framework/config/model_configs.py
@@ -27,7 +27,10 @@ class StarkeModelConfig:
     dataset_path: Path
     path_to_ai4anim: Path
     pae_epochs: int
+    pae_learning_rate: float
     gnn_epochs: int
+    gnn_learning_rate: float
+    gnn_dropout: float
 
     def __post_init__(self) -> None:
         """Convert string paths to Path objects if needed."""
@@ -64,5 +67,15 @@ class StarkeModelConfig:
             return f"PAE epochs must be greater than 0, got: {self.pae_epochs}"
         if self.gnn_epochs <= 0:
             return f"GNN epochs must be greater than 0, got: {self.gnn_epochs}"
+
+        # Validate learning rates > 0
+        if self.pae_learning_rate <= 0:
+            return f"PAE learning rate must be greater than 0, got: {self.pae_learning_rate}"
+        if self.gnn_learning_rate <= 0:
+            return f"GNN learning rate must be greater than 0, got: {self.gnn_learning_rate}"
+
+        # Validate dropout between 0 and 1
+        if not (0 <= self.gnn_dropout <= 1):
+            return f"GNN dropout must be between 0 and 1, got: {self.gnn_dropout}"
 
         return None

--- a/python/ml_framework/starke_model_config.json
+++ b/python/ml_framework/starke_model_config.json
@@ -1,6 +1,9 @@
 {
     "dataset_path": "../../../Survivor_Training_Data",
+    "gnn_dropout": 0.3,
     "gnn_epochs": 2,
+    "gnn_learning_rate": 1e-04,
     "pae_epochs": 2,
+    "pae_learning_rate": 1e-04,
     "path_to_ai4anim": "../../../AI4Animation-master"
 }


### PR DESCRIPTION
# Description
* Exposing pae epoch, gnn epoch and dropout to AniMHost config node. This is ~10 code lines per parameter without refactoring included in this pr.
* Replaced previous double/float spinbox input with line edit to avoid having to define precision explicitly
* Added documentation for adding hyperparams to DEV_GUIDE
* Unrelated TRAINING.md edit due to [PR 51](https://github.com/FilmakademieRnd/AnimHost/pull/51)

# Testing
* Test run with modified learning rate and dropout. Checked changes in the AI4Animation Network.py files
<img width="602" height="473" alt="image" src="https://github.com/user-attachments/assets/033e138d-4a54-41cc-8169-9b67f47f5a06" />
