### PR TITLE
AnimHost Quadruped Experiments - Indexing fixes

### DIFF
--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -230,9 +230,6 @@ void AssimpLoaderPlugin::onFolderSelectionChanged()
 
 void AssimpLoaderPlugin::loadAnimationData(aiAnimation* pASSIMPAnimation, Skeleton* pSkeleton, Animation* pAnimation, aiNode* pNode)
 {
-	pAnimation->mDurationFrames = pASSIMPAnimation->mDuration;
-
-
 	pAnimation->mBones = std::vector<Bone>(pSkeleton->mNumBones, Bone());
 	for (auto var : pSkeleton->bone_names)
 	{
@@ -241,6 +238,8 @@ void AssimpLoaderPlugin::loadAnimationData(aiAnimation* pASSIMPAnimation, Skelet
 
 	AssimpHelper::setAnimationRestingPositionFromAssimpNode(*pNode, *pSkeleton, pAnimation);
 
+	// Calculate mDurationFrames from actual keyframe count instead of mDuration
+	int maxKeyframes = 0;
 	for (int idx = 0; idx < pASSIMPAnimation->mNumChannels; idx++)
 	{
 
@@ -259,6 +258,19 @@ void AssimpLoaderPlugin::loadAnimationData(aiAnimation* pASSIMPAnimation, Skelet
 		int numKeysRot = channel->mNumRotationKeys;
 		int numKeysPos = channel->mNumPositionKeys;
 		int numKeysScl = channel->mNumScalingKeys;
+
+		// Track maximum keyframe count across all channels
+		maxKeyframes = std::max(maxKeyframes, numKeysRot);
+		maxKeyframes = std::max(maxKeyframes, numKeysPos);
+		maxKeyframes = std::max(maxKeyframes, numKeysScl);
+
+		// Log first channel's keyframe counts to see actual frame count
+		if (idx == 0) {
+			qDebug() << "[AssimpLoader] First channel actual keyframe counts:"
+			         << "mNumRotationKeys:" << numKeysRot
+			         << "mNumPositionKeys:" << numKeysPos
+			         << "mNumScalingKeys:" << numKeysScl;
+		}
 
 		for (int i = 0; i < numKeysRot; i++)
 		{
@@ -284,6 +296,11 @@ void AssimpLoaderPlugin::loadAnimationData(aiAnimation* pASSIMPAnimation, Skelet
 			pAnimation->mBones.at(boneIndex).mScaleKeys.push_back({ (float)sclKey.mTime,scale });
 		}
 	}
+	pAnimation->mDurationFrames = maxKeyframes;
+
+	qDebug() << "[AssimpLoader] mDurationFrames set from keyframe count:" << pAnimation->mDurationFrames
+	         << "(ASSIMP mDuration was:" << pASSIMPAnimation->mDuration << ")"
+	         << "- Difference:" << (pAnimation->mDurationFrames - (int)pASSIMPAnimation->mDuration);
 }
 
 

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/LocomotionPreprocess/LocomotionPreprocessNode.cpp
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/LocomotionPreprocess/LocomotionPreprocessNode.cpp
@@ -382,7 +382,7 @@ std::vector<float> LocomotionPreprocessNode::prepareTrajectoryData(int reference
 
 	// For output data, we only need to calculate the trajectory for the future steps.
 	// 6 is the start index for future steps, including pivot of frame range. Might need to change this if the number of samples changes.
-	int startIdx = isOutput ? 7 : 0;
+	int startIdx = isOutput ? (pastSamples + 1) : 0;
 
 	FrameRange frameRange(numSamples, 60, refIdx, startIdx);
 
@@ -695,7 +695,7 @@ void LocomotionPreprocessNode::writeMetaData() {
 					featureCount += 3;
 
 					//Root Trajectory. start index at 6 for future steps
-					for (int i = 7; i < numSamples; i++) {
+					for (int i = (pastSamples + 1); i < numSamples; i++) {
 						header += ",out_root_pos_x_" + QString::number(i);
 						header += ",out_root_pos_y_" + QString::number(i);
 						header += ",out_root_fwd_x_" + QString::number(i);

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/LocomotionPreprocess/LocomotionPreprocessNode.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/LocomotionPreprocess/LocomotionPreprocessNode.h
@@ -44,9 +44,9 @@ private:
   
 
 
-    int numSamples = 13;
-    int pastSamples = 6;
-    int futureSamples = 6; // past samples + reference frame + future samples = numSamples
+    int numSamples = 13; // Number of trajectory samples (-60:+60 frames, every 10 frames -> 13 samples)
+    int pastSamples = 6; // Number of past samples
+    int pastFrames = 60; // Number of past frames sampled
 
     int rootbone_idx = 0;
 

--- a/python/ml_framework/DEV_GUIDE.md
+++ b/python/ml_framework/DEV_GUIDE.md
@@ -69,7 +69,7 @@ Release/
 
 ## Run all tests
 ```bash
-cd python/ml_framework/tests
+cd python/ml_framework
 pytest tests/ -v
 ```
 

--- a/python/ml_framework/data/motion_preprocessing.py
+++ b/python/ml_framework/data/motion_preprocessing.py
@@ -194,7 +194,7 @@ def get_future_window_values(row, phaseValues, selected_columns, window_size=7):
     return window[selected_columns].values.flatten()
 
 def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=60, start_index=0, offset=0):
-    """"
+    """
     Retrieves the window values for a given row in a DataFrame based on a specified frame range.
 
     Parameters:
@@ -209,7 +209,7 @@ def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=6
     Returns:
     - The flattened array of values from the window.
 
-    """    
+    """
     seq_id, frame = row.name
 
     # Offset by one frame because target pivot is expected to be a future frame

--- a/python/ml_framework/data/motion_preprocessing.py
+++ b/python/ml_framework/data/motion_preprocessing.py
@@ -189,12 +189,11 @@ def get_future_window_values(row, phaseValues, selected_columns, window_size=7):
         print(f"Progress: {seq_id}/{frame}", end='\r')
     return window[selected_columns].values.flatten()
 
-def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=1, start_index=0, is_future=False):
+def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=60, start_index=0):
     seq_id, frame = row.name
     
-    frame = frame + 1 if is_future else frame
     # Initialize FrameRange with the given parameters
-    frame_range = FrameRange(num_samples=num_samples, fps=60, reference_frame=frame, start_index=start_index)
+    frame_range = FrameRange(num_samples=num_samples, fps=fps, reference_frame=frame, start_index=start_index)
     
     # Generate the frame indices within the specified range
     frame_indices = list(frame_range)
@@ -367,7 +366,7 @@ class MotionProcessor:
         select_combined = select_phase2d + select_amplitude + select_freq
 
         # Collect Future Phase Values
-        future_phase_values = self.InputData.apply(get_window_values_, args=(self.PhaseData, select_combined, 13, 60, 6, True), axis=1)
+        future_phase_values = self.InputData.apply(get_window_values_, args=(self.PhaseData, select_combined, 13, 60, 6), axis=1)
         #future_phase_values = self.InputData.apply(get_future_window_values, args=(self.PhaseData, select_combined, 7), axis=1)
         
         dfOutDataMrg = pd.merge(df_OutputData, future_phase_values.to_frame(), on=['SeqId','Frame'],how='inner')

--- a/python/ml_framework/data/motion_preprocessing.py
+++ b/python/ml_framework/data/motion_preprocessing.py
@@ -9,15 +9,16 @@ import time
 import os
 
 class FrameRange:
-    def __init__(self, num_samples, fps, reference_frame, start_index):
-        
+    def __init__(self, num_samples, fps, reference_frame, start_index, max_frame=None):
+
         self.fps = fps
         self.reference_frame = reference_frame
         self.current_sample_index = start_index
+        self.max_frame = max_frame
 
         # Ensure total frames is odd, so the reference frame is always in the middle
         self.total_frames = 2 * fps + 1
-        
+
         self.num_samples = num_samples
         if num_samples % 2 == 0:
             self.num_samples += 1
@@ -41,6 +42,9 @@ class FrameRange:
 
             if frameIndex < 0:
                 frameIndex = 0
+
+            if self.max_frame is not None and frameIndex > self.max_frame:
+                frameIndex = self.max_frame
 
             return frameIndex
     
@@ -189,16 +193,34 @@ def get_future_window_values(row, phaseValues, selected_columns, window_size=7):
         print(f"Progress: {seq_id}/{frame}", end='\r')
     return window[selected_columns].values.flatten()
 
-def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=60, start_index=0):
+def get_window_values_(row, phaseValues, selected_columns, num_samples=13, fps=60, start_index=0, offset=0):
+    """"
+    Retrieves the window values for a given row in a DataFrame based on a specified frame range.
+
+    Parameters:
+    - row: The row containing the sequence ID and frame number.
+    - phaseValues: The DataFrame containing the phase values.
+    - selected_columns: The list of columns to select from the window.
+    - num_samples: The number of samples to retrieve within the window (default is 13).
+    - fps: The frames per second to determine the total frame range (default is 60)
+    - start_index: The starting index for the window (default is 0).
+    - offset: The frame offset to apply to the row reference frame (default is 0).
+
+    Returns:
+    - The flattened array of values from the window.
+
+    """    
     seq_id, frame = row.name
-    
-    # Initialize FrameRange with the given parameters
-    frame_range = FrameRange(num_samples=num_samples, fps=fps, reference_frame=frame, start_index=start_index)
-    
+
+    # Offset by one frame because target pivot is expected to be a future frame
+    frame = frame + offset if offset else frame
+    max_frame = phaseValues.loc[seq_id].index.max()
+    # Initialize FrameRange with the given parameters. Guard with max_frame to prevent out-of-bounds access due to offset.
+    frame_range = FrameRange(num_samples=num_samples, fps=fps, reference_frame=frame, start_index=start_index, max_frame=max_frame)
+
     # Generate the frame indices within the specified range
     frame_indices = list(frame_range)
-    
-    #print(frame_indices)
+
     # Create a list of tuples for the multi-index selection
     index_tuples = [(seq_id, f) for f in frame_indices]
 
@@ -366,7 +388,7 @@ class MotionProcessor:
         select_combined = select_phase2d + select_amplitude + select_freq
 
         # Collect Future Phase Values
-        future_phase_values = self.InputData.apply(get_window_values_, args=(self.PhaseData, select_combined, 13, 60, 6), axis=1)
+        future_phase_values = self.InputData.apply(get_window_values_, args=(self.PhaseData, select_combined, 13, 60, 6, 1), axis=1)
         #future_phase_values = self.InputData.apply(get_future_window_values, args=(self.PhaseData, select_combined, 7), axis=1)
         
         dfOutDataMrg = pd.merge(df_OutputData, future_phase_values.to_frame(), on=['SeqId','Frame'],how='inner')

--- a/python/ml_framework/external/starke_training.py
+++ b/python/ml_framework/external/starke_training.py
@@ -158,6 +158,18 @@ def _init_pae_network_script(
         logger.error(f"Failed to update PAE Network.py: {error}")
         raise RuntimeError(f"Failed to update PAE Network.py: {error}")
 
+    # Fix single-sample last-batch crash: PAE params have shape [batch, channels, 1]
+    # due to unsqueeze(2). .squeeze() removes ALL size-1 dims, so a batch of 1 collapses
+    # to 1D and breaks indexing throughout training and parameter saving.
+    # .squeeze(-1) only removes the trailing dim, preserving batch regardless of size.
+    # params[0] (phase) has no trailing 1 so .squeeze(-1) is safely a no-op there.
+    # Backup already created by write_script_variables above.
+    content = pae_network_path.read_text(encoding="utf-8")
+    fixed = re.sub(r"(params\[\d+\]\))\.squeeze\(\)", r"\1.squeeze(-1)", content)
+    if fixed != content:
+        pae_network_path.write_text(fixed, encoding="utf-8")
+        logger.info("Applied squeeze(-1) fix to PAE Network.py")
+
     # Log all changes
     logger.info("Successfully updated PAE Network.py with:")
     for key, new_value in updates.items():
@@ -478,36 +490,43 @@ def move_pae_artifacts(path_to_ai4anim: Path, dest_dir: Path) -> bool:
     """
     Move PAE training artifacts to destination directory.
 
-    Moves files from AI4Animation/SIGGRAPH_2022/PyTorch/PAE/Training/ to dest_dir/PAE/Training/
-    Overwrites existing files with the same name.
+    Moves:
+    - AI4Animation/.../PAE/Training/ to dest_dir/PAE/Training/
+    - AI4Animation/.../PAE/Dataset/ to dest_dir/PAE/Dataset/
 
     :param path_to_ai4anim: Path to AI4Animation framework
     :param dest_dir: Destination directory for artifacts
     :return: True on success, False on failure
     """
     try:
-        pae_source = pae_path(path_to_ai4anim) / "Training"
-        pae_dest = dest_dir / "PAE" / "Training"
+        pae_base = pae_path(path_to_ai4anim)
+        dirs_to_move = ["Training", "Dataset"]
+        total_moved = 0
 
-        if not pae_source.exists():
-            logger.warning(f"PAE training directory not found: {pae_source}")
-            return False
+        for dir_name in dirs_to_move:
+            pae_source = pae_base / dir_name
+            pae_dest = dest_dir / "PAE" / dir_name
 
-        if not pae_source.is_dir():
-            logger.error(f"PAE training path is not a directory: {pae_source}")
-            return False
+            if not pae_source.exists():
+                logger.warning(f"PAE {dir_name} directory not found: {pae_source}")
+                continue
 
-        # Create destination directory
-        pae_dest.mkdir(parents=True, exist_ok=True)
+            if not pae_source.is_dir():
+                logger.error(f"PAE {dir_name} path is not a directory: {pae_source}")
+                continue
 
-        # Move all files from source to destination
-        moved_count = 0
-        for item in pae_source.iterdir():
-            dest_item = pae_dest / item.name
-            shutil.move(str(item), str(dest_item))
-            moved_count += 1
+            # Create destination directory
+            pae_dest.mkdir(parents=True, exist_ok=True)
 
-        logger.info(f"Moved {moved_count} PAE training artifacts from {pae_source} to {pae_dest}")
+            # Move all files from source to destination
+            for item in pae_source.iterdir():
+                dest_item = pae_dest / item.name
+                shutil.move(str(item), str(dest_item))
+                total_moved += 1
+
+            logger.info(f"Moved PAE {dir_name} artifacts from {pae_source} to {pae_dest}")
+
+        logger.info(f"Moved {total_moved} PAE artifacts total")
         return True
 
     except Exception as e:
@@ -519,38 +538,45 @@ def move_gnn_artifacts(path_to_ai4anim: Path, dest_dir: Path) -> bool:
     """
     Move GNN training artifacts to destination directory.
 
-    Moves files from AI4Animation/SIGGRAPH_2022/PyTorch/GNN/Training/ to dest_dir/GNN/Training/
-    Overwrites existing files with the same name.
+    Moves:
+    - AI4Animation/.../GNN/Training/ to dest_dir/GNN/Training/
+    - AI4Animation/.../GNN/Data/ to dest_dir/GNN/Data/
 
     :param path_to_ai4anim: Path to AI4Animation framework
     :param dest_dir: Destination directory for artifacts
     :return: True on success, False on failure
     """
     try:
-        gnn_source = gnn_path(path_to_ai4anim) / "Training"
-        gnn_dest = dest_dir / "GNN" / "Training"
+        gnn_base = gnn_path(path_to_ai4anim)
+        dirs_to_move = ["Training", "Data"]
+        total_moved = 0
 
-        if not gnn_source.exists():
-            logger.warning(f"GNN training directory not found: {gnn_source}")
-            return False
+        for dir_name in dirs_to_move:
+            gnn_source = gnn_base / dir_name
+            gnn_dest = dest_dir / "GNN" / dir_name
 
-        if not gnn_source.is_dir():
-            logger.error(f"GNN training path is not a directory: {gnn_source}")
-            return False
-
-        # Create destination directory
-        gnn_dest.mkdir(parents=True, exist_ok=True)
-
-        # Move all files from source to destination (skip placeholder.txt)
-        moved_count = 0
-        for item in gnn_source.iterdir():
-            if item.name == "placeholder.txt":
+            if not gnn_source.exists():
+                logger.warning(f"GNN {dir_name} directory not found: {gnn_source}")
                 continue
-            dest_item = gnn_dest / item.name
-            shutil.move(str(item), str(dest_item))
-            moved_count += 1
 
-        logger.info(f"Moved {moved_count} GNN training artifacts from {gnn_source} to {gnn_dest}")
+            if not gnn_source.is_dir():
+                logger.error(f"GNN {dir_name} path is not a directory: {gnn_source}")
+                continue
+
+            # Create destination directory
+            gnn_dest.mkdir(parents=True, exist_ok=True)
+
+            # Move all files from source to destination (skip placeholder.txt)
+            for item in gnn_source.iterdir():
+                if item.name == "placeholder.txt":
+                    continue
+                dest_item = gnn_dest / item.name
+                shutil.move(str(item), str(dest_item))
+                total_moved += 1
+
+            logger.info(f"Moved GNN {dir_name} artifacts from {gnn_source} to {gnn_dest}")
+
+        logger.info(f"Moved {total_moved} GNN artifacts total")
         return True
 
     except Exception as e:

--- a/python/ml_framework/tests/test_motion_preprocessing.py
+++ b/python/ml_framework/tests/test_motion_preprocessing.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+"""Tests for motion_preprocessing utilities."""
+
+import pytest
+from data.motion_preprocessing import FrameRange
+
+
+def test_frame_range_full_window():
+    """start_index=0 returns all 13 frames centered on the reference frame."""
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=120, start_index=0))
+    assert result == [60, 70, 80, 90, 100, 110, 120, 130, 140, 150, 160, 170, 180]
+
+
+def test_frame_range_from_reference_frame():
+    """start_index=6 starts at the reference frame, returning 7 frames."""
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=120, start_index=6))
+    assert result == [120, 130, 140, 150, 160, 170, 180]
+
+
+def test_frame_range_future_window():
+    """start_index=7 skips the reference frame, returning only future frames."""
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=120, start_index=7))
+    assert result == [130, 140, 150, 160, 170, 180]
+
+
+def test_frame_range_includes_reference_frame():
+    """start_index=6 lands on the reference frame (odd reference_frame=121)."""
+    frame = 120 + 1  # +1 to reference leads to off by one error if input is 60 to 180 frames
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=frame, start_index=6))
+    assert result == [121, 131, 141, 151, 161, 171, 181]

--- a/python/ml_framework/tests/test_motion_preprocessing.py
+++ b/python/ml_framework/tests/test_motion_preprocessing.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 """Tests for motion_preprocessing utilities."""
 
-import pytest
 from data.motion_preprocessing import FrameRange
 
 
@@ -24,7 +23,12 @@ def test_frame_range_future_window():
 
 
 def test_frame_range_includes_reference_frame():
-    """start_index=6 lands on the reference frame (odd reference_frame=121)."""
-    frame = 120 + 1  # +1 to reference leads to off by one error if input is 60 to 180 frames
-    result = list(FrameRange(num_samples=13, fps=60, reference_frame=frame, start_index=6))
-    assert result == [121, 131, 141, 151, 161, 171, 181]
+    """start_index=6 with reference_frame=121, clamped to max_frame=180."""
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=121, start_index=6, max_frame=180))
+    assert result == [121, 131, 141, 151, 161, 171, 180]
+
+
+def test_frame_range_clamps_to_max_frame():
+    """When max_frame is lower, trailing frames repeat the max_frame value."""
+    result = list(FrameRange(num_samples=13, fps=60, reference_frame=121, start_index=6, max_frame=170))
+    assert result == [121, 131, 141, 151, 161, 170, 170]

--- a/python/ml_framework/training.py
+++ b/python/ml_framework/training.py
@@ -36,6 +36,8 @@ def main() -> None:
         experiment.run()
         experiment.preserve()
     except Exception as e:
+        if experiment is not None:
+            experiment.preserve()
         tracker.log_exception("Starke training failed", e)
         raise
     finally:


### PR DESCRIPTION
## Description
* Fixed 54 indexing delta in `LocomotionPreprocessNode` due to writing with sample count instead of frame count offset
* Fixed missing frame due to incorrect duration setting in `AssimpLoaderPlugin`
* Fixed off by one error in motion_processing script, clamping to max frames
* Added preservation of trained models to training framework
* Added preservation of training artifacts for crashing training framework runs
* Added dynamic starke pae fix for loosing batch dimension for single sample batches

## Testing
- [x] Ran existing and added Python tests `pytest tests/ -v`
- [x] Run Full Survivor training run on this PR (f949160, e2509_20260316_0)