### PR TITLE
AnimHost Quadruped Experiments - Quadruped Inference

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,23 @@
 {
-    "cmake.configureOnOpen": false
+    "cmake.configureOnOpen": false,
+    "search.exclude": {
+        "**/build": true,
+        "**/vcpkg": true,
+        "**/glm": true,
+        "**/__pycache__": true,
+        "**/.pytest_cache": true,
+        "**/onnxruntime/lib": true,
+        "**/*.pth": true,
+        "**/*.onnx": true,
+        "**/*.dll": true,
+        "**/*.lib": true,
+        "**/*.obj": true,
+        "**/*.pdb": true
+    },
+    "files.watcherExclude": {
+        "**/build/**": true,
+        "**/vcpkg/**": true,
+        "**/__pycache__/**": true,
+        "**/.pytest_cache/**": true
+    }
 }

--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -25,7 +25,7 @@
 #include "animhosthelper.h"
 
 #include <assimp/DefaultLogger.hpp>
-
+#include <assimp/config.h>
 
 #include <QFileInfo>
 #include <QDateTime>
@@ -459,7 +459,7 @@ void AssimpLoaderPlugin::importAssimpData()
 {
 	Assimp::Importer importer;
 	importer.SetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, false);
-
+	importer.SetPropertyFloat(AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY, 1.0f);
 
 	// Create a logger instance
 	Assimp::DefaultLogger::create("", Assimp::Logger::DEBUGGING);
@@ -475,7 +475,8 @@ void AssimpLoaderPlugin::importAssimpData()
 	const  aiScene* scene = importer.ReadFile(SourceFilePath.toStdString(),
 		aiProcess_SortByPType |
 		aiProcess_ValidateDataStructure |  // Validate imported data integrity
-		aiProcess_PopulateArmatureData);   // Ensure bone/animation data is complete
+		aiProcess_PopulateArmatureData |   // Ensure bone/animation data is complete
+		aiProcess_GlobalScale);            // Apply AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY to positions
 
 	auto keys = scene->mMetaData->mKeys;
 

--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -25,7 +25,7 @@
 #include "animhosthelper.h"
 
 #include <assimp/DefaultLogger.hpp>
-#include <assimp/config.h>
+
 
 #include <QFileInfo>
 #include <QDateTime>
@@ -459,7 +459,7 @@ void AssimpLoaderPlugin::importAssimpData()
 {
 	Assimp::Importer importer;
 	importer.SetPropertyBool(AI_CONFIG_IMPORT_FBX_PRESERVE_PIVOTS, false);
-	importer.SetPropertyFloat(AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY, 1.0f);
+
 
 	// Create a logger instance
 	Assimp::DefaultLogger::create("", Assimp::Logger::DEBUGGING);
@@ -473,10 +473,7 @@ void AssimpLoaderPlugin::importAssimpData()
 	Assimp::DefaultLogger::get()->attachStream(new AssimpQTStream, severity);
 
 	const  aiScene* scene = importer.ReadFile(SourceFilePath.toStdString(),
-		aiProcess_SortByPType |
-		aiProcess_ValidateDataStructure |  // Validate imported data integrity
-		aiProcess_PopulateArmatureData |   // Ensure bone/animation data is complete
-		aiProcess_GlobalScale);            // Apply AI_CONFIG_GLOBAL_SCALE_FACTOR_KEY to positions
+		aiProcess_SortByPType);
 
 	auto keys = scene->mMetaData->mKeys;
 

--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -523,7 +523,9 @@ void AssimpLoaderPlugin::importAssimpData()
 	Assimp::DefaultLogger::get()->attachStream(new AssimpQTStream, severity);
 
 	const  aiScene* scene = importer.ReadFile(SourceFilePath.toStdString(),
-		aiProcess_SortByPType);
+		aiProcess_SortByPType |
+		aiProcess_ValidateDataStructure |  // Validate imported data integrity
+		aiProcess_PopulateArmatureData);   // Ensure bone/animation data is complete
 
 	auto keys = scene->mMetaData->mKeys;
 

--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -20,8 +20,6 @@
  
 #include "assimploaderplugin.h"
 #include <iostream>
-#include <algorithm>
-#include <cfloat>
 
 #include "assimphelper.h"
 #include "animhosthelper.h"
@@ -215,54 +213,6 @@ void AssimpLoaderPlugin::run() {
 
 			emitDataUpdate(0);
 			emitDataUpdate(1);
-
-			// Log character dimensions (median bounding box across frames)
-			{
-				auto anim   = _animation->getData();
-				int nFrames = anim->mDurationFrames;
-				int nBones  = static_cast<int>(anim->mBones.size());
-
-				if (nFrames > 0 && nBones > 0) {
-					std::vector<float> extX, extY, extZ;
-					extX.reserve(nFrames); extY.reserve(nFrames); extZ.reserve(nFrames);
-
-					for (int f = 0; f < nFrames; ++f) {
-						float minX =  FLT_MAX, maxX = -FLT_MAX;
-						float minY =  FLT_MAX, maxY = -FLT_MAX;
-						float minZ =  FLT_MAX, maxZ = -FLT_MAX;
-						for (const auto& bone : anim->mBones) {
-							glm::vec3 p = bone.GetPosition(f);
-							minX = std::min(minX, p.x); maxX = std::max(maxX, p.x);
-							minY = std::min(minY, p.y); maxY = std::max(maxY, p.y);
-							minZ = std::min(minZ, p.z); maxZ = std::max(maxZ, p.z);
-						}
-						extX.push_back(maxX - minX);
-						extY.push_back(maxY - minY);
-						extZ.push_back(maxZ - minZ);
-					}
-
-					// nth_element-based percentile (operates on a copy)
-					auto pct = [](std::vector<float> v, float p) -> float {
-						int idx = static_cast<int>(p / 100.0f * (static_cast<int>(v.size()) - 1));
-						std::nth_element(v.begin(), v.begin() + idx, v.end());
-						return v[idx];
-					};
-
-					auto fmt = [](float v) { return QString::number(static_cast<double>(v), 'f', 2); };
-
-					float medY = pct(extY, 50);
-					const char* unit = (medY > 10.0f) ? " (~cm)" : " (~m)";
-
-					qDebug() << "── Character dimensions" << unit
-					         << "| frames:" << nFrames << "| bones:" << nBones;
-					qDebug() << "  X (lateral) :" << fmt(pct(extX, 50))
-					         << " [p10=" << fmt(pct(extX, 10)) << " p90=" << fmt(pct(extX, 90)) << "]";
-					qDebug() << "  Y (vertical):" << fmt(medY)
-					         << " [p10=" << fmt(pct(extY, 10)) << " p90=" << fmt(pct(extY, 90)) << "]";
-					qDebug() << "  Z (depth)   :" << fmt(pct(extZ, 50))
-					         << " [p10=" << fmt(pct(extZ, 10)) << " p90=" << fmt(pct(extZ, 90)) << "]";
-				}
-			}
 
 			qDebug() << "Processing " << shorty << " done.";
 

--- a/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
+++ b/AnimHost/animHost_Plugins/AssimpLoader/assimploaderplugin.cpp
@@ -20,6 +20,8 @@
  
 #include "assimploaderplugin.h"
 #include <iostream>
+#include <algorithm>
+#include <cfloat>
 
 #include "assimphelper.h"
 #include "animhosthelper.h"
@@ -213,6 +215,54 @@ void AssimpLoaderPlugin::run() {
 
 			emitDataUpdate(0);
 			emitDataUpdate(1);
+
+			// Log character dimensions (median bounding box across frames)
+			{
+				auto anim   = _animation->getData();
+				int nFrames = anim->mDurationFrames;
+				int nBones  = static_cast<int>(anim->mBones.size());
+
+				if (nFrames > 0 && nBones > 0) {
+					std::vector<float> extX, extY, extZ;
+					extX.reserve(nFrames); extY.reserve(nFrames); extZ.reserve(nFrames);
+
+					for (int f = 0; f < nFrames; ++f) {
+						float minX =  FLT_MAX, maxX = -FLT_MAX;
+						float minY =  FLT_MAX, maxY = -FLT_MAX;
+						float minZ =  FLT_MAX, maxZ = -FLT_MAX;
+						for (const auto& bone : anim->mBones) {
+							glm::vec3 p = bone.GetPosition(f);
+							minX = std::min(minX, p.x); maxX = std::max(maxX, p.x);
+							minY = std::min(minY, p.y); maxY = std::max(maxY, p.y);
+							minZ = std::min(minZ, p.z); maxZ = std::max(maxZ, p.z);
+						}
+						extX.push_back(maxX - minX);
+						extY.push_back(maxY - minY);
+						extZ.push_back(maxZ - minZ);
+					}
+
+					// nth_element-based percentile (operates on a copy)
+					auto pct = [](std::vector<float> v, float p) -> float {
+						int idx = static_cast<int>(p / 100.0f * (static_cast<int>(v.size()) - 1));
+						std::nth_element(v.begin(), v.begin() + idx, v.end());
+						return v[idx];
+					};
+
+					auto fmt = [](float v) { return QString::number(static_cast<double>(v), 'f', 2); };
+
+					float medY = pct(extY, 50);
+					const char* unit = (medY > 10.0f) ? " (~cm)" : " (~m)";
+
+					qDebug() << "── Character dimensions" << unit
+					         << "| frames:" << nFrames << "| bones:" << nBones;
+					qDebug() << "  X (lateral) :" << fmt(pct(extX, 50))
+					         << " [p10=" << fmt(pct(extX, 10)) << " p90=" << fmt(pct(extX, 90)) << "]";
+					qDebug() << "  Y (vertical):" << fmt(medY)
+					         << " [p10=" << fmt(pct(extY, 10)) << " p90=" << fmt(pct(extY, 90)) << "]";
+					qDebug() << "  Z (depth)   :" << fmt(pct(extZ, 50))
+					         << " [p10=" << fmt(pct(extZ, 10)) << " p90=" << fmt(pct(extZ, 90)) << "]";
+				}
+			}
 
 			qDebug() << "Processing " << shorty << " done.";
 

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.cpp
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.cpp
@@ -31,6 +31,11 @@
 #include <algorithm>
 #include <chrono>
 
+#include <QFile>
+#include <QTextStream>
+#include <QDataStream>
+#include <QDir>
+
 #include <glm/gtx/matrix_decompose.hpp>
 #include <glm/gtx/vector_angle.hpp>
 
@@ -203,6 +208,11 @@ void GNNController::prepareInput()
 		//Inference
 		std::vector<float> inferenceOutputValues = network->RunInference(input_values);
 
+		if (bExportData) {
+			_exportInputSamples.push_back(input_values);
+			_exportOutputSamples.push_back(inferenceOutputValues);
+		}
+
 		if (inferenceOutputValues.size() == 0) {
 			qCritical() << "Stopping Animation Generation. Inference failed.";
 			return;
@@ -289,7 +299,15 @@ void GNNController::prepareInput()
 
 	BuildAnimationSequence(genJointRot, rootSeries);
 
-} 
+	if (bExportData && !_exportInputSamples.empty()) {
+		QDir().mkpath(_exportDir);
+		writeExportMetadata();
+		writeExportSequences();
+		writeExportBinary();
+		bExportData = false;
+	}
+
+}
 
 TrajectoryFrameData GNNController::BuildTrajectoryFrameData(const RootSeries& rootSeries, glm::mat4 Root)
 {
@@ -852,4 +870,159 @@ void GNNController::UpdatePlotData(const TrajectoryFrameData& inTrajFrame, const
 }
 
 void GNNController::DrawPlot() {
+}
+
+// ── Inference Data Export ─────────────────────────────────────────────────────
+
+void GNNController::writeExportMetadata() const
+{
+	int numBones = static_cast<int>(initJointPos.size());
+
+	// ── Input header ──
+	int numFeatX = 0;
+	QString headerX;
+
+	for (int i = 0; i < totalKeys; i++) {
+		headerX += ",root_pos_x_" + QString::number(i);
+		headerX += ",root_pos_y_" + QString::number(i);
+		headerX += ",root_fwd_x_" + QString::number(i);
+		headerX += ",root_fwd_y_" + QString::number(i);
+		headerX += ",root_vel_x_" + QString::number(i);
+		headerX += ",root_vel_y_" + QString::number(i);
+		headerX += ",root_speed_" + QString::number(i);
+		numFeatX += 7;
+	}
+
+	for (int i = 0; i < numBones; i++) {
+		QString boneName = QString::fromStdString(skeleton->bone_names_reverse.at(i));
+		headerX += ",jpos_x_" + boneName;
+		headerX += ",jpos_y_" + boneName;
+		headerX += ",jpos_z_" + boneName;
+		headerX += ",jrot_0_" + boneName;
+		headerX += ",jrot_1_" + boneName;
+		headerX += ",jrot_2_" + boneName;
+		headerX += ",jrot_3_" + boneName;
+		headerX += ",jrot_4_" + boneName;
+		headerX += ",jrot_5_" + boneName;
+		headerX += ",jvel_x_" + boneName;
+		headerX += ",jvel_y_" + boneName;
+		headerX += ",jvel_z_" + boneName;
+		numFeatX += 12;
+	}
+
+	for (int f = 0; f < totalKeys; f++) {
+		for (int c = 0; c < numPhaseChannel; c++) {
+			headerX += ",in_phase_x_t" + QString::number(f) + "_c" + QString::number(c);
+			headerX += ",in_phase_y_t" + QString::number(f) + "_c" + QString::number(c);
+			numFeatX += 2;
+		}
+	}
+	headerX += "\n";
+
+	// ── Output header ──
+	int numFeatY = 0;
+	QString headerY;
+
+	headerY += ",delta_x,delta_y,delta_angle";
+	numFeatY += 3;
+
+	for (int i = pastKeys + 1; i < totalKeys; i++) {
+		headerY += ",out_root_pos_x_" + QString::number(i);
+		headerY += ",out_root_pos_y_" + QString::number(i);
+		headerY += ",out_root_fwd_x_" + QString::number(i);
+		headerY += ",out_root_fwd_y_" + QString::number(i);
+		headerY += ",out_root_vel_x_" + QString::number(i);
+		headerY += ",out_root_vel_y_" + QString::number(i);
+		headerY += ",out_root_speed_" + QString::number(i);
+		numFeatY += 7;
+	}
+
+	for (int i = 0; i < numBones; i++) {
+		QString boneName = QString::fromStdString(skeleton->bone_names_reverse.at(i));
+		headerY += ",out_jpos_x_" + boneName;
+		headerY += ",out_jpos_y_" + boneName;
+		headerY += ",out_jpos_z_" + boneName;
+		headerY += ",out_jrot_0_" + boneName;
+		headerY += ",out_jrot_1_" + boneName;
+		headerY += ",out_jrot_2_" + boneName;
+		headerY += ",out_jrot_3_" + boneName;
+		headerY += ",out_jrot_4_" + boneName;
+		headerY += ",out_jrot_5_" + boneName;
+		headerY += ",out_jvel_x_" + boneName;
+		headerY += ",out_jvel_y_" + boneName;
+		headerY += ",out_jvel_z_" + boneName;
+		numFeatY += 12;
+	}
+
+	for (int f = 0; f < futureKeys + 1; f++) {
+		for (int c = 0; c < numPhaseChannel; c++) {
+			headerY += ",out_phase_x_t" + QString::number(f) + "_c" + QString::number(c);
+			headerY += ",out_phase_y_t" + QString::number(f) + "_c" + QString::number(c);
+			numFeatY += 2;
+		}
+		for (int c = 0; c < numPhaseChannel; c++) {
+			headerY += ",out_amp_t" + QString::number(f) + "_c" + QString::number(c);
+			numFeatY++;
+		}
+		for (int c = 0; c < numPhaseChannel; c++) {
+			headerY += ",out_freq_t" + QString::number(f) + "_c" + QString::number(c);
+			numFeatY++;
+		}
+	}
+	headerY += "\n";
+
+	QFile metaFile(_exportDir + "/metadata.txt");
+	if (metaFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QTextStream out(&metaFile);
+		out << QString::number(numFeatX) << headerX;
+		out << QString::number(numFeatY) << headerY;
+	} else {
+		qWarning() << "GNNController: failed to write metadata.txt to" << _exportDir;
+	}
+}
+
+void GNNController::writeExportSequences() const
+{
+	QFile seqFile(_exportDir + "/sequences_mann.txt");
+	if (seqFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QTextStream out(&seqFile);
+		for (int idx = 0; idx < static_cast<int>(_exportInputSamples.size()); idx++) {
+			out << "0 " << idx << " Standard inference gnn_inference\n";
+		}
+	} else {
+		qWarning() << "GNNController: failed to write sequences_mann.txt to" << _exportDir;
+	}
+}
+
+void GNNController::writeExportBinary() const
+{
+	// data_X.bin
+	{
+		QFile fileX(_exportDir + "/data_X.bin");
+		if (fileX.open(QIODevice::WriteOnly)) {
+			QDataStream out(&fileX);
+			out.setByteOrder(QDataStream::LittleEndian);
+			for (const auto& sample : _exportInputSamples) {
+				out.writeRawData(reinterpret_cast<const char*>(sample.data()),
+					static_cast<int>(sample.size() * sizeof(float)));
+			}
+		} else {
+			qWarning() << "GNNController: failed to write data_X.bin to" << _exportDir;
+		}
+	}
+
+	// data_Y.bin
+	{
+		QFile fileY(_exportDir + "/data_Y.bin");
+		if (fileY.open(QIODevice::WriteOnly)) {
+			QDataStream out(&fileY);
+			out.setByteOrder(QDataStream::LittleEndian);
+			for (const auto& sample : _exportOutputSamples) {
+				out.writeRawData(reinterpret_cast<const char*>(sample.data()),
+					static_cast<int>(sample.size() * sizeof(float)));
+			}
+		} else {
+			qWarning() << "GNNController: failed to write data_Y.bin to" << _exportDir;
+		}
+	}
 }

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.cpp
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.cpp
@@ -301,9 +301,7 @@ void GNNController::prepareInput()
 
 	if (bExportData && !_exportInputSamples.empty()) {
 		QDir().mkpath(_exportDir);
-		writeExportMetadata();
-		writeExportSequences();
-		writeExportBinary();
+		writeExportData();
 		bExportData = false;
 	}
 
@@ -874,111 +872,96 @@ void GNNController::DrawPlot() {
 
 // ── Inference Data Export ─────────────────────────────────────────────────────
 
-void GNNController::writeExportMetadata() const
+QStringList GNNController::buildInputLabels() const
 {
 	int numBones = static_cast<int>(initJointPos.size());
-
-	// ── Input header ──
-	int numFeatX = 0;
-	QString headerX;
+	QStringList labels;
 
 	for (int i = 0; i < totalKeys; i++) {
-		headerX += ",root_pos_x_" + QString::number(i);
-		headerX += ",root_pos_y_" + QString::number(i);
-		headerX += ",root_fwd_x_" + QString::number(i);
-		headerX += ",root_fwd_y_" + QString::number(i);
-		headerX += ",root_vel_x_" + QString::number(i);
-		headerX += ",root_vel_y_" + QString::number(i);
-		headerX += ",root_speed_" + QString::number(i);
-		numFeatX += 7;
+		labels << "root_pos_x_" + QString::number(i);
+		labels << "root_pos_y_" + QString::number(i);
+		labels << "root_fwd_x_" + QString::number(i);
+		labels << "root_fwd_y_" + QString::number(i);
+		labels << "root_vel_x_" + QString::number(i);
+		labels << "root_vel_y_" + QString::number(i);
+		labels << "root_speed_" + QString::number(i);
 	}
 
 	for (int i = 0; i < numBones; i++) {
 		QString boneName = QString::fromStdString(skeleton->bone_names_reverse.at(i));
-		headerX += ",jpos_x_" + boneName;
-		headerX += ",jpos_y_" + boneName;
-		headerX += ",jpos_z_" + boneName;
-		headerX += ",jrot_0_" + boneName;
-		headerX += ",jrot_1_" + boneName;
-		headerX += ",jrot_2_" + boneName;
-		headerX += ",jrot_3_" + boneName;
-		headerX += ",jrot_4_" + boneName;
-		headerX += ",jrot_5_" + boneName;
-		headerX += ",jvel_x_" + boneName;
-		headerX += ",jvel_y_" + boneName;
-		headerX += ",jvel_z_" + boneName;
-		numFeatX += 12;
+		labels << "jpos_x_" + boneName;
+		labels << "jpos_y_" + boneName;
+		labels << "jpos_z_" + boneName;
+		labels << "jrot_0_" + boneName;
+		labels << "jrot_1_" + boneName;
+		labels << "jrot_2_" + boneName;
+		labels << "jrot_3_" + boneName;
+		labels << "jrot_4_" + boneName;
+		labels << "jrot_5_" + boneName;
+		labels << "jvel_x_" + boneName;
+		labels << "jvel_y_" + boneName;
+		labels << "jvel_z_" + boneName;
 	}
 
+	int phaseIdx = 1;
 	for (int f = 0; f < totalKeys; f++) {
 		for (int c = 0; c < numPhaseChannel; c++) {
-			headerX += ",in_phase_x_t" + QString::number(f) + "_c" + QString::number(c);
-			headerX += ",in_phase_y_t" + QString::number(f) + "_c" + QString::number(c);
-			numFeatX += 2;
+			labels << "PhaseSpace-" + QString::number(phaseIdx++);
+			labels << "PhaseSpace-" + QString::number(phaseIdx++);
 		}
 	}
-	headerX += "\n";
 
-	// ── Output header ──
-	int numFeatY = 0;
-	QString headerY;
+	return labels;
+}
 
-	headerY += ",delta_x,delta_y,delta_angle";
-	numFeatY += 3;
+QStringList GNNController::buildOutputLabels() const
+{
+	int numBones = static_cast<int>(initJointPos.size());
+	QStringList labels;
+
+	labels << "delta_x" << "delta_y" << "delta_angle";
 
 	for (int i = pastKeys + 1; i < totalKeys; i++) {
-		headerY += ",out_root_pos_x_" + QString::number(i);
-		headerY += ",out_root_pos_y_" + QString::number(i);
-		headerY += ",out_root_fwd_x_" + QString::number(i);
-		headerY += ",out_root_fwd_y_" + QString::number(i);
-		headerY += ",out_root_vel_x_" + QString::number(i);
-		headerY += ",out_root_vel_y_" + QString::number(i);
-		headerY += ",out_root_speed_" + QString::number(i);
-		numFeatY += 7;
+		labels << "out_root_pos_x_" + QString::number(i);
+		labels << "out_root_pos_y_" + QString::number(i);
+		labels << "out_root_fwd_x_" + QString::number(i);
+		labels << "out_root_fwd_y_" + QString::number(i);
+		labels << "out_root_vel_x_" + QString::number(i);
+		labels << "out_root_vel_y_" + QString::number(i);
+		labels << "out_root_speed_" + QString::number(i);
 	}
 
 	for (int i = 0; i < numBones; i++) {
 		QString boneName = QString::fromStdString(skeleton->bone_names_reverse.at(i));
-		headerY += ",out_jpos_x_" + boneName;
-		headerY += ",out_jpos_y_" + boneName;
-		headerY += ",out_jpos_z_" + boneName;
-		headerY += ",out_jrot_0_" + boneName;
-		headerY += ",out_jrot_1_" + boneName;
-		headerY += ",out_jrot_2_" + boneName;
-		headerY += ",out_jrot_3_" + boneName;
-		headerY += ",out_jrot_4_" + boneName;
-		headerY += ",out_jrot_5_" + boneName;
-		headerY += ",out_jvel_x_" + boneName;
-		headerY += ",out_jvel_y_" + boneName;
-		headerY += ",out_jvel_z_" + boneName;
-		numFeatY += 12;
+		labels << "out_jpos_x_" + boneName;
+		labels << "out_jpos_y_" + boneName;
+		labels << "out_jpos_z_" + boneName;
+		labels << "out_jrot_0_" + boneName;
+		labels << "out_jrot_1_" + boneName;
+		labels << "out_jrot_2_" + boneName;
+		labels << "out_jrot_3_" + boneName;
+		labels << "out_jrot_4_" + boneName;
+		labels << "out_jrot_5_" + boneName;
+		labels << "out_jvel_x_" + boneName;
+		labels << "out_jvel_y_" + boneName;
+		labels << "out_jvel_z_" + boneName;
 	}
 
+	int updateIdx = 1;
 	for (int f = 0; f < futureKeys + 1; f++) {
 		for (int c = 0; c < numPhaseChannel; c++) {
-			headerY += ",out_phase_x_t" + QString::number(f) + "_c" + QString::number(c);
-			headerY += ",out_phase_y_t" + QString::number(f) + "_c" + QString::number(c);
-			numFeatY += 2;
+			labels << "PhaseUpdate-" + QString::number(updateIdx++);
+			labels << "PhaseUpdate-" + QString::number(updateIdx++);
 		}
 		for (int c = 0; c < numPhaseChannel; c++) {
-			headerY += ",out_amp_t" + QString::number(f) + "_c" + QString::number(c);
-			numFeatY++;
+			labels << "PhaseUpdate-" + QString::number(updateIdx++);
 		}
 		for (int c = 0; c < numPhaseChannel; c++) {
-			headerY += ",out_freq_t" + QString::number(f) + "_c" + QString::number(c);
-			numFeatY++;
+			labels << "PhaseUpdate-" + QString::number(updateIdx++);
 		}
 	}
-	headerY += "\n";
 
-	QFile metaFile(_exportDir + "/metadata.txt");
-	if (metaFile.open(QIODevice::WriteOnly | QIODevice::Text)) {
-		QTextStream out(&metaFile);
-		out << QString::number(numFeatX) << headerX;
-		out << QString::number(numFeatY) << headerY;
-	} else {
-		qWarning() << "GNNController: failed to write metadata.txt to" << _exportDir;
-	}
+	return labels;
 }
 
 void GNNController::writeExportSequences() const
@@ -994,35 +977,74 @@ void GNNController::writeExportSequences() const
 	}
 }
 
-void GNNController::writeExportBinary() const
+void GNNController::writeBinaryFile(const QString& path, const std::vector<std::vector<float>>& samples) const
 {
-	// data_X.bin
-	{
-		QFile fileX(_exportDir + "/data_X.bin");
-		if (fileX.open(QIODevice::WriteOnly)) {
-			QDataStream out(&fileX);
-			out.setByteOrder(QDataStream::LittleEndian);
-			for (const auto& sample : _exportInputSamples) {
-				out.writeRawData(reinterpret_cast<const char*>(sample.data()),
-					static_cast<int>(sample.size() * sizeof(float)));
-			}
-		} else {
-			qWarning() << "GNNController: failed to write data_X.bin to" << _exportDir;
+	QFile file(path);
+	if (file.open(QIODevice::WriteOnly)) {
+		QDataStream out(&file);
+		out.setByteOrder(QDataStream::LittleEndian);
+		for (const auto& sample : samples) {
+			out.writeRawData(reinterpret_cast<const char*>(sample.data()),
+				static_cast<int>(sample.size() * sizeof(float)));
 		}
+	} else {
+		qWarning() << "GNNController: failed to write" << path;
+	}
+}
+
+void GNNController::writeLabelsFile(const QString& path, const QStringList& labels) const
+{
+	QFile file(path);
+	if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QTextStream out(&file);
+		for (int i = 0; i < labels.size(); i++) {
+			out << "[" << i << "] " << labels[i] << "\n";
+		}
+	} else {
+		qWarning() << "GNNController: failed to write" << path;
+	}
+}
+
+void GNNController::writeShapeFile(const QString& path, int numSamples, int numFeatures) const
+{
+	QFile file(path);
+	if (file.open(QIODevice::WriteOnly | QIODevice::Text)) {
+		QTextStream out(&file);
+		out << numSamples << "\n" << numFeatures;
+	} else {
+		qWarning() << "GNNController: failed to write" << path;
+	}
+}
+
+void GNNController::writeExportData() const
+{
+	int numSamples = static_cast<int>(_exportInputSamples.size());
+	int numInputFeatures = _exportInputSamples.empty() ? 0 : static_cast<int>(_exportInputSamples[0].size());
+	int numOutputFeatures = _exportOutputSamples.empty() ? 0 : static_cast<int>(_exportOutputSamples[0].size());
+
+	QStringList inputLabels = buildInputLabels();
+	QStringList outputLabels = buildOutputLabels();
+
+	if (inputLabels.size() != numInputFeatures) {
+		qWarning() << "GNNController: input label count" << inputLabels.size()
+			<< "does not match feature count" << numInputFeatures;
+	}
+	if (outputLabels.size() != numOutputFeatures) {
+		qWarning() << "GNNController: output label count" << outputLabels.size()
+			<< "does not match feature count" << numOutputFeatures;
 	}
 
-	// data_Y.bin
-	{
-		QFile fileY(_exportDir + "/data_Y.bin");
-		if (fileY.open(QIODevice::WriteOnly)) {
-			QDataStream out(&fileY);
-			out.setByteOrder(QDataStream::LittleEndian);
-			for (const auto& sample : _exportOutputSamples) {
-				out.writeRawData(reinterpret_cast<const char*>(sample.data()),
-					static_cast<int>(sample.size() * sizeof(float)));
-			}
-		} else {
-			qWarning() << "GNNController: failed to write data_Y.bin to" << _exportDir;
-		}
-	}
+	writeBinaryFile(_exportDir + "/Input.bin", _exportInputSamples);
+	writeBinaryFile(_exportDir + "/Output.bin", _exportOutputSamples);
+
+	writeLabelsFile(_exportDir + "/InputLabels.txt", inputLabels);
+	writeLabelsFile(_exportDir + "/OutputLabels.txt", outputLabels);
+
+	writeShapeFile(_exportDir + "/InputShape.txt", numSamples, numInputFeatures);
+	writeShapeFile(_exportDir + "/OutputShape.txt", numSamples, numOutputFeatures);
+
+	writeExportSequences();
+
+	qDebug() << "GNNController: exported" << numSamples << "samples to" << _exportDir
+		<< "(input:" << numInputFeatures << "features, output:" << numOutputFeatures << "features)";
 }

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
@@ -158,6 +158,12 @@ private:
     std::vector<float> input_values;
     std::vector<float> output_values;
 
+    // Data export
+    bool bExportData = false;
+    QString _exportDir;
+    std::vector<std::vector<float>> _exportInputSamples;
+    std::vector<std::vector<float>> _exportOutputSamples;
+
     //Plotting
     #ifdef DEBUG_PLOT
     matplot::figure_handle figure = nullptr;
@@ -206,6 +212,13 @@ public:
     std::shared_ptr<Animation> GetAnimationOut();
     std::shared_ptr<DebugSignal> GetDebugSignal(){return debugSignal; }
 
+    void EnableDataExport(const QString& dir) {
+        bExportData = true;
+        _exportDir = dir;
+        _exportInputSamples.clear();
+        _exportOutputSamples.clear();
+    }
+
 private:
 
     void InitPlot();
@@ -239,5 +252,9 @@ private:
     float CalcPhaseValue(glm::vec2 phase);
 
     glm::mat4 updateRootTranform(const glm::mat4& pos, const glm::vec3& delta, int genIdx);
+
+    void writeExportMetadata() const;
+    void writeExportSequences() const;
+    void writeExportBinary() const;
 
 };

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
@@ -89,8 +89,8 @@ private:
     int numPhaseChannel = 5;
 
     /*Mix Weights*/
-    float rootTranslationWeight = 0.5f;
-    float rootRotationWeight = 0.5f;
+    float rootTranslationWeight = 0.0f;
+    float rootRotationWeight = 0.0f;
 
     /**
      * Exponential mix factor for rotations between predicted future trajectory values and control trajectory values.
@@ -106,7 +106,7 @@ private:
      * Trajectory Update Bias.
 	 * Controls the mix between predicted future trajectory values and the the current trajectory values.
      */
-    float networkControlBias = 1.f / 3.f;
+    float networkControlBias = 1.f;
 
     /**
      * Phase Update Bias.

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
@@ -253,8 +253,14 @@ private:
 
     glm::mat4 updateRootTranform(const glm::mat4& pos, const glm::vec3& delta, int genIdx);
 
-    void writeExportMetadata() const;
     void writeExportSequences() const;
-    void writeExportBinary() const;
+
+    // GNN training format export
+    void writeExportData() const;
+    QStringList buildInputLabels() const;
+    QStringList buildOutputLabels() const;
+    void writeLabelsFile(const QString& path, const QStringList& labels) const;
+    void writeShapeFile(const QString& path, int numSamples, int numFeatures) const;
+    void writeBinaryFile(const QString& path, const std::vector<std::vector<float>>& samples) const;
 
 };

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNController.h
@@ -95,18 +95,18 @@ private:
     /**
      * Exponential mix factor for rotations between predicted future trajectory values and control trajectory values.
      */
-    float tauRotation = 1.f;
+    float tauRotation = 0.3f;
 
     /**
 	 * Exponential mix factor for positions between predicted future trajectory values and control trajectory values.
      */
-	float tauTranslation = 1.f;
+	float tauTranslation = 0.5f;
 
     /**
      * Trajectory Update Bias.
 	 * Controls the mix between predicted future trajectory values and the the current trajectory values.
      */
-    float networkControlBias = 1.f;
+    float networkControlBias = 1./3.f;
 
     /**
      * Phase Update Bias.
@@ -200,7 +200,7 @@ public:
     void SetControlPath(std::shared_ptr<ControlPath> path);
 
     void SetMixWeights(float translation, float rotation, float controlTauRotation, float controlTauTranslation,
-        float networkControlBias = 1./3.f, float networkPhaseBias = 1./3.f) {
+        float networkControlBias = 1./3.f, float networkPhaseBias = 0.5f) {
         this->rootTranslationWeight = translation; 
         this->rootRotationWeight = rotation; 
         this->tauRotation = controlTauRotation; 

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNNode.cpp
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNNode.cpp
@@ -245,12 +245,13 @@ void GNNNode::run()
                     controller->SetAnimationIn(animation);
                     controller->SetSkeleton(skeleton);
                     controller->SetControlPath(controlPath);
-                    controller->SetMixWeights(_mixRootTranslation->value(), _mixRootRotation->value(), 
+                    controller->SetMixWeights(_mixRootTranslation->value(), _mixRootRotation->value(),
                         _mixControlPathRotation->value(), _mixControlPathTranslation->value(),
                         _networkControlBias->value()/100.f, _networkPhaseBias->value()/100.f);
 
-                    //dummy data
-           
+                    if (_cbExportData && _cbExportData->isChecked() && !_exportPath.isEmpty())
+                        controller->EnableDataExport(_exportPath);
+
                     controller->prepareInput();
 
 					if (auto animOut = controller->GetAnimationOut()) {
@@ -353,9 +354,15 @@ QWidget* GNNNode::embeddedWidget()
 
        layout->addLayout(gridLayout);
 
+       _cbExportData = new QCheckBox("Export Inference Data", _widget);
+       _exportFolderWidget = new FolderSelectionWidget(_widget, FolderSelectionWidget::Directory);
+       layout->addWidget(_cbExportData);
+       layout->addWidget(_exportFolderWidget);
+
        _widget->setLayout(layout);
 
        connect(_fileSelectionWidget, &FolderSelectionWidget::directoryChanged, this, &GNNNode::onFileSelectionChanged);
+       connect(_exportFolderWidget, &FolderSelectionWidget::directoryChanged, this, [this]() { _exportPath = _exportFolderWidget->GetSelectedDirectory(); });
 
        _widget->setStyleSheet("QHeaderView::section {background-color:rgba(64, 64, 64, 0%);""border: 0px solid white;""}"
            "QWidget{background-color:rgba(64, 64, 64, 0%);""color: white;}"

--- a/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNNode.h
+++ b/AnimHost/animHost_Plugins/DeepLocomotionPlugin/GNN/GNNNode.h
@@ -3,6 +3,7 @@
 
 #include "../DeepLocomotionPlugin_global.h"
 #include <QMetaType>
+#include <QCheckBox>
 #include <pluginnodeinterface.h>
 #include "GNNController.h"
 #include "UIUtils.h"
@@ -41,6 +42,11 @@ private:
     QDoubleSpinBox* _mixControlPathRotation = nullptr;
 	QSlider* _networkPhaseBias = nullptr;
 	QSlider* _networkControlBias = nullptr;
+
+    // Export UI
+    FolderSelectionWidget* _exportFolderWidget = nullptr;
+    QCheckBox*             _cbExportData       = nullptr;
+    QString                _exportPath;
 
 public:
     GNNNode();

--- a/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
@@ -24,6 +24,8 @@
 #include <QDebug>
 #include <QDataStream>
 #include <QElapsedTimer>
+#include <QFile>
+#include <QCoreApplication>
 #include <iostream>
 
 void AnimHostMessageSender::requestStart() {
@@ -141,6 +143,12 @@ void AnimHostMessageSender::streamAnimationData()
         SerializePose(animData, charObj, sceneNodeList, msgBodyAnim, (int) animFrame);
         mutex.unlock();
 
+        if (dumpMessageToFile) {
+            QString dumpPath = QCoreApplication::applicationDirPath() + "/animhost_pose_dump.json";
+            dumpPoseToJson(animData, charObj, sceneNodeList, (int) animFrame, dumpPath);
+            dumpMessageToFile = false;
+        }
+
         // Create ZMQ Message
         createNewMessage(_globalTimer->getLocalTimeStamp(), ZMQMessageHandler::MessageType::PARAMETERUPDATE, msgBodyAnim);
 
@@ -226,6 +234,12 @@ void AnimHostMessageSender::sendAnimationDataBlock()
     SerializeAnimation(animData, charObj, sceneNodeList, msgBodyAnim, 0);
     mutex.unlock();
     qDebug() << "BLOCK: SerializeAnimation done, msgBodyAnim size:" << msgBodyAnim->size();
+
+    if (dumpMessageToFile) {
+        QString dumpPath = QCoreApplication::applicationDirPath() + "/animhost_animation_dump.json";
+        dumpAnimationToJson(animData, charObj, sceneNodeList, dumpPath);
+        dumpMessageToFile = false;
+    }
 
     qDebug() << "BLOCK: calling createNewMessage...";
     createNewMessage( _globalTimer->getLocalTimeStamp(), ZMQMessageHandler::MessageType::PARAMETERUPDATE, msgBodyAnim);
@@ -523,7 +537,213 @@ void AnimHostMessageSender::SerializeAnimation(std::shared_ptr<Animation> animDa
 
 }
 
+void AnimHostMessageSender::dumpPoseToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
+                                           std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, int frame, const QString& path) {
+    QJsonObject root;
+    root["messageType"] = "PARAMETERUPDATE";
+    root["mode"] = "pose";
+    root["frame"] = frame;
+    root["targetSceneID"] = (int)ZMQMessageHandler::getTargetSceneID();
+    root["characterObjectID"] = (int)character->sceneObjectID;
 
+    // Resolve bone map
+    std::vector<int> skeletonFallback;
+    const std::vector<int>* boneMapPtr = nullptr;
+    if (!character->skinnedMeshList.empty()) {
+        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
+        root["boneMapSource"] = "skinnedMesh";
+    } else if (character->skeletonObjIDs.size() > 1) {
+        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
+        boneMapPtr = &skeletonFallback;
+        root["boneMapSource"] = "skeletonFallback";
+    } else {
+        root["error"] = "no bone map available";
+        QFile file(path);
+        file.open(QIODevice::WriteOnly);
+        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+        return;
+    }
+    const std::vector<int>& boneMapIDs = *boneMapPtr;
+    int nBones = (int)boneMapIDs.size();
+    root["nBones"] = nBones;
+
+    // Root transform
+    glm::quat rootQuat = animData->mBones.at(0).GetOrientation(frame);
+    glm::vec3 rootPos = animData->mBones.at(0).GetPosition(frame);
+    QJsonObject rootTransform;
+    rootTransform["position"] = QJsonObject{{"x", rootPos.x}, {"y", rootPos.y}, {"z", rootPos.z}};
+    rootTransform["rotation"] = QJsonObject{{"x", rootQuat.x}, {"y", rootQuat.y}, {"z", rootQuat.z}, {"w", rootQuat.w}};
+    rootTransform["paramID_pos"] = 0;
+    rootTransform["paramID_rot"] = 1;
+    root["root"] = rootTransform;
+
+    // Bones
+    QJsonArray bonesArray;
+    for (int i = 0; i < nBones; i++) {
+        int boneID = boneMapIDs.at(i);
+        if (boneID < 0 || boneID >= (int)sceneNodeList->mSceneNodeObjectSequence.size()) continue;
+        std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
+        if (boneName == "heel_02_R" || boneName == "heel_02_L") continue;
+
+        int animDataBoneID = -1;
+        for (int j = 0; j < (int)animData->mBones.size(); j++) {
+            if (boneName == animData->mBones.at(j).mName) { animDataBoneID = j; break; }
+        }
+        if (animDataBoneID < 0) continue;
+
+        glm::quat boneQuat = animData->mBones.at(animDataBoneID).GetOrientation(frame);
+        glm::vec3 bonePos = animData->mBones.at(animDataBoneID).GetPosition(frame);
+
+        QJsonObject boneObj;
+        boneObj["index"] = i;
+        boneObj["boneID"] = boneID;
+        boneObj["boneName"] = QString::fromStdString(boneName);
+        boneObj["animDataBoneID"] = animDataBoneID;
+        boneObj["paramID_rot"] = i + 3 + 3;
+        boneObj["paramID_pos"] = i + nBones + 3 + 3;
+        boneObj["rotation"] = QJsonObject{{"x", boneQuat.x}, {"y", boneQuat.y}, {"z", boneQuat.z}, {"w", boneQuat.w}};
+        boneObj["position"] = QJsonObject{{"x", bonePos.x}, {"y", bonePos.y}, {"z", bonePos.z}};
+        bonesArray.append(boneObj);
+    }
+    root["bones"] = bonesArray;
+
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+        qDebug() << "Pose dump written to:" << path;
+    } else {
+        qWarning() << "Failed to open dump file:" << path;
+    }
+}
+
+void AnimHostMessageSender::dumpAnimationToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
+                                                std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, const QString& path) {
+    QJsonObject root;
+    root["messageType"] = "PARAMETERUPDATE";
+    root["mode"] = "animation";
+    root["targetSceneID"] = (int)ZMQMessageHandler::getTargetSceneID();
+    root["characterObjectID"] = (int)character->sceneObjectID;
+
+    if (animData->mBones.empty()) {
+        root["error"] = "no bones in animation data";
+        QFile file(path);
+        file.open(QIODevice::WriteOnly);
+        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+        return;
+    }
+
+    // Resolve bone map
+    std::vector<int> skeletonFallback;
+    const std::vector<int>* boneMapPtr = nullptr;
+    if (!character->skinnedMeshList.empty()) {
+        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
+        root["boneMapSource"] = "skinnedMesh";
+    } else if (character->skeletonObjIDs.size() > 1) {
+        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
+        boneMapPtr = &skeletonFallback;
+        root["boneMapSource"] = "skeletonFallback";
+    } else {
+        root["error"] = "no bone map available";
+        QFile file(path);
+        file.open(QIODevice::WriteOnly);
+        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+        return;
+    }
+    const std::vector<int>& boneMapIDs = *boneMapPtr;
+    int nBones = (int)boneMapIDs.size();
+    root["nBones"] = nBones;
+    root["animBoneCount"] = (int)animData->mBones.size();
+
+    // Root keyframes
+    QJsonObject rootObj;
+    rootObj["paramID_pos"] = 0;
+    rootObj["paramID_rot"] = 1;
+
+    auto& rootBone = animData->mBones.at(0);
+    rootObj["positionKeyCount"] = (int)rootBone.mPositonKeys.size();
+    rootObj["rotationKeyCount"] = (int)rootBone.mRotationKeys.size();
+
+    // Root position keyframes (limit to first 5 + last for readability)
+    QJsonArray rootPosKeys;
+    for (int k = 0; k < (int)rootBone.mPositonKeys.size(); k++) {
+        auto& key = rootBone.mPositonKeys.at(k);
+        QJsonObject kObj;
+        kObj["time_s"] = key.timeStamp / 60.0;
+        kObj["position"] = QJsonObject{{"x", key.position.x}, {"y", key.position.y}, {"z", key.position.z}};
+        rootPosKeys.append(kObj);
+    }
+    rootObj["positionKeys"] = rootPosKeys;
+
+    QJsonArray rootRotKeys;
+    for (int k = 0; k < (int)rootBone.mRotationKeys.size(); k++) {
+        auto& key = rootBone.mRotationKeys.at(k);
+        QJsonObject kObj;
+        kObj["time_s"] = key.timeStamp / 60.0;
+        kObj["rotation"] = QJsonObject{{"x", key.orientation.x}, {"y", key.orientation.y}, {"z", key.orientation.z}, {"w", key.orientation.w}};
+        rootRotKeys.append(kObj);
+    }
+    rootObj["rotationKeys"] = rootRotKeys;
+    root["root"] = rootObj;
+
+    // Bones
+    QJsonArray bonesArray;
+    for (int i = 0; i < nBones; i++) {
+        int boneID = boneMapIDs.at(i);
+        if (boneID < 0 || boneID >= (int)sceneNodeList->mSceneNodeObjectSequence.size()) continue;
+        std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
+        if (boneName == "heel_02_R" || boneName == "heel_02_L") continue;
+
+        int animDataBoneID = -1;
+        for (int j = 0; j < (int)animData->mBones.size(); j++) {
+            if (boneName == animData->mBones.at(j).mName) { animDataBoneID = j; break; }
+        }
+        if (animDataBoneID < 0) continue;
+
+        QJsonObject boneObj;
+        boneObj["index"] = i;
+        boneObj["boneID"] = boneID;
+        boneObj["boneName"] = QString::fromStdString(boneName);
+        boneObj["animDataBoneID"] = animDataBoneID;
+        boneObj["paramID_rot"] = i + 3 + 3;
+        boneObj["paramID_pos"] = i + nBones + 3 + 3;
+
+        auto& bone = animData->mBones.at(animDataBoneID);
+        boneObj["positionKeyCount"] = (int)bone.mPositonKeys.size();
+        boneObj["rotationKeyCount"] = (int)bone.mRotationKeys.size();
+
+        // Include all keyframes
+        if (!bone.mPositonKeys.empty()) {
+            QJsonArray posKeys;
+            for (auto& key : bone.mPositonKeys) {
+                QJsonObject kObj;
+                kObj["time_s"] = key.timeStamp / 60.0;
+                kObj["position"] = QJsonObject{{"x", key.position.x}, {"y", key.position.y}, {"z", key.position.z}};
+                posKeys.append(kObj);
+            }
+            boneObj["positionKeys"] = posKeys;
+        }
+
+        QJsonArray rotKeys;
+        for (auto& key : bone.mRotationKeys) {
+            QJsonObject kObj;
+            kObj["time_s"] = key.timeStamp / 60.0;
+            kObj["rotation"] = QJsonObject{{"x", key.orientation.x}, {"y", key.orientation.y}, {"z", key.orientation.z}, {"w", key.orientation.w}};
+            rotKeys.append(kObj);
+        }
+        boneObj["rotationKeys"] = rotKeys;
+
+        bonesArray.append(boneObj);
+    }
+    root["bones"] = bonesArray;
+
+    QFile file(path);
+    if (file.open(QIODevice::WriteOnly)) {
+        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
+        qDebug() << "Animation dump written to:" << path;
+    } else {
+        qWarning() << "Failed to open dump file:" << path;
+    }
+}
 
 
 // Creating ZMQ Parameter Update Message Body from T value

--- a/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
@@ -203,37 +203,57 @@ void AnimHostMessageSender::sendAnimationDataBlock()
 {
     qDebug() << "Starting BLOCK AnimHost Message Sender";
 
+    // Null checks before proceeding
+    if (!animData)   { qCritical() << "BLOCK: animData is null!";      sendBlock = false; return; }
+    if (!charObj)    { qCritical() << "BLOCK: charObj is null!";       sendBlock = false; return; }
+    if (!sceneNodeList) { qCritical() << "BLOCK: sceneNodeList is null!"; sendBlock = false; return; }
+    if (!_globalTimer)  { qCritical() << "BLOCK: _globalTimer is null!";  sendBlock = false; return; }
+
+    qDebug() << "BLOCK: animData bones:" << animData->mBones.size()
+             << "| charObj sceneObjectID:" << charObj->sceneObjectID
+             << "| sceneNodeList size:" << sceneNodeList->mSceneNodeObjectSequence.size()
+             << "| skinnedMeshList size:" << charObj->skinnedMeshList.size()
+             << "| skeletonObjIDs size:" << charObj->skeletonObjIDs.size();
 
     QByteArray* msgBodyAnim = new QByteArray();
-   
+
     bool locked = false;
 
     m_pauseMutex.lock();
 
+    qDebug() << "BLOCK: calling SerializeAnimation...";
     mutex.lock();
     SerializeAnimation(animData, charObj, sceneNodeList, msgBodyAnim, 0);
     mutex.unlock();
-    
-    
+    qDebug() << "BLOCK: SerializeAnimation done, msgBodyAnim size:" << msgBodyAnim->size();
+
+    qDebug() << "BLOCK: calling createNewMessage...";
     createNewMessage( _globalTimer->getLocalTimeStamp(), ZMQMessageHandler::MessageType::PARAMETERUPDATE, msgBodyAnim);
+    qDebug() << "BLOCK: createNewMessage done";
 
     // Sending LOCK message to the character (necessary for applying root animations)
     if (!locked) {
+        qDebug() << "BLOCK: sending LOCK message for sceneObjectID:" << charObj->sceneObjectID;
         createLockMessage(_globalTimer->getLocalTimeStamp(), charObj->sceneObjectID, true);
         int retunLockVal = sendSocket->send((void*)lockMessage->data(), lockMessage->size());
+        qDebug() << "BLOCK: LOCK send returned:" << retunLockVal;
         locked = true;
     }
 
     // Sending new parameter update message
+    qDebug() << "BLOCK: sending PARAMETERUPDATE message, size:" << message->size();
     int retunVal = sendSocket->send((void*)message->data(), message->size());
+    qDebug() << "BLOCK: PARAMETERUPDATE send returned:" << retunVal;
 
     QThread::msleep(1);
 
     m_pauseMutex.unlock();
-        
+
     //UNLOCK CHARACTER
+    qDebug() << "BLOCK: sending UNLOCK message";
     createLockMessage(_globalTimer->getLocalTimeStamp(), charObj->sceneObjectID, false);
     int retunUnlockVal = sendSocket->send((void*)lockMessage->data(), lockMessage->size());
+    qDebug() << "BLOCK: UNLOCK send returned:" << retunUnlockVal;
     locked = false;
 
     // Set _working to false -> process cannot be aborted anymore
@@ -241,6 +261,7 @@ void AnimHostMessageSender::sendAnimationDataBlock()
     sendBlock = false;
     mutex.unlock();
 
+    qDebug() << "BLOCK: sendAnimationDataBlock complete";
 }
 
 
@@ -275,7 +296,21 @@ void AnimHostMessageSender::SerializePose(std::shared_ptr<Animation> animData, s
     // Target Scene ID
     int targetSceneID = ZMQMessageHandler::getTargetSceneID();
     int charRootID = character->characterRootID;
-    int nBones = character->skinnedMeshList.at(0).boneMapIDs.size();    // The number of Bones in the targeted character
+
+    // Resolve bone map: prefer skinnedMesh boneMapIDs, fall back to skeletonObjIDs (skip index 0 = armature root)
+    std::vector<int> skeletonFallback;
+    const std::vector<int>* boneMapPtr = nullptr;
+    if (!character->skinnedMeshList.empty()) {
+        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
+    } else if (character->skeletonObjIDs.size() > 1) {
+        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
+        boneMapPtr = &skeletonFallback;
+    } else {
+        qCritical() << "SerializePose: no bone map available";
+        return;
+    }
+    const std::vector<int>& boneMapIDs = *boneMapPtr;
+    int nBones = (int)boneMapIDs.size();
 
     // Root TRS
     // Getting Bone Object Rotation Quaternion
@@ -302,7 +337,7 @@ void AnimHostMessageSender::SerializePose(std::shared_ptr<Animation> animData, s
         // This WILL NOT WORK for RETARGETED animations
 
         // Getting boneName given the parameterID
-        int boneID = character->skinnedMeshList.at(0).boneMapIDs.at(i);
+        int boneID = boneMapIDs.at(i);
         std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
 
 
@@ -354,9 +389,31 @@ void AnimHostMessageSender::SerializeAnimation(std::shared_ptr<Animation> animDa
 
     // Target Scene ID
     int targetSceneID = ZMQMessageHandler::getTargetSceneID();
-    int nBones = character->skinnedMeshList.at(0).boneMapIDs.size();    // The number of Bones in the targeted character
-	QString boneRotationMap = "";
 
+    if (animData->mBones.empty()) { qCritical() << "SerializeAnimation: animData has no bones!"; return; }
+
+    // Resolve bone map: prefer skinnedMesh boneMapIDs, fall back to skeletonObjIDs (skip index 0 = armature root)
+    std::vector<int> skeletonFallback;
+    const std::vector<int>* boneMapPtr = nullptr;
+    if (!character->skinnedMeshList.empty()) {
+        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
+        qDebug() << "SerializeAnimation: using skinnedMesh boneMapIDs";
+    } else if (character->skeletonObjIDs.size() > 1) {
+        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
+        boneMapPtr = &skeletonFallback;
+        qDebug() << "SerializeAnimation: using skeletonObjIDs fallback, root sceneNode:"
+                 << QString::fromStdString(sceneNodeList->mSceneNodeObjectSequence.at(character->skeletonObjIDs.at(0)).objectName);
+    } else {
+        qCritical() << "SerializeAnimation: no bone map available (skinnedMeshList empty, skeletonObjIDs size=" << character->skeletonObjIDs.size() << ")";
+        return;
+    }
+    const std::vector<int>& boneMapIDs = *boneMapPtr;
+    int nBones = (int)boneMapIDs.size();
+
+    qDebug() << "SerializeAnimation: targetSceneID=" << targetSceneID << "nBones=" << nBones
+             << "animBones=" << animData->mBones.size()
+             << "sceneNodes=" << sceneNodeList->mSceneNodeObjectSequence.size();
+	QString boneRotationMap = "";
 
     // Prepare animation data for objects TRS
     if (true) {
@@ -398,10 +455,15 @@ void AnimHostMessageSender::SerializeAnimation(std::shared_ptr<Animation> animDa
 
 
 	//Prepare animation data for bones
+    qDebug() << "SerializeAnimation: iterating" << nBones << "bones";
     for (int i = 0; i < nBones; i++)
     {
 
-        int boneID = character->skinnedMeshList.at(0).boneMapIDs.at(i);
+        int boneID = boneMapIDs.at(i);
+        if (boneID < 0 || boneID >= (int)sceneNodeList->mSceneNodeObjectSequence.size()) {
+            qCritical() << "SerializeAnimation: boneID" << boneID << "out of range (sceneNodes:" << sceneNodeList->mSceneNodeObjectSequence.size() << ") at i=" << i;
+            continue;
+        }
         std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
 
 		// HOTFIX Accomodate Survivor specific special case for heel_02_R and heel_02_L (Heel breaks Character IK rig?) 

--- a/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.cpp
@@ -24,8 +24,6 @@
 #include <QDebug>
 #include <QDataStream>
 #include <QElapsedTimer>
-#include <QFile>
-#include <QCoreApplication>
 #include <iostream>
 
 void AnimHostMessageSender::requestStart() {
@@ -143,12 +141,6 @@ void AnimHostMessageSender::streamAnimationData()
         SerializePose(animData, charObj, sceneNodeList, msgBodyAnim, (int) animFrame);
         mutex.unlock();
 
-        if (dumpMessageToFile) {
-            QString dumpPath = QCoreApplication::applicationDirPath() + "/animhost_pose_dump.json";
-            dumpPoseToJson(animData, charObj, sceneNodeList, (int) animFrame, dumpPath);
-            dumpMessageToFile = false;
-        }
-
         // Create ZMQ Message
         createNewMessage(_globalTimer->getLocalTimeStamp(), ZMQMessageHandler::MessageType::PARAMETERUPDATE, msgBodyAnim);
 
@@ -211,71 +203,41 @@ void AnimHostMessageSender::sendAnimationDataBlock()
 {
     qDebug() << "Starting BLOCK AnimHost Message Sender";
 
-    // Null checks before proceeding
-    if (!animData)   { qCritical() << "BLOCK: animData is null!";      sendBlock = false; return; }
-    if (!charObj)    { qCritical() << "BLOCK: charObj is null!";       sendBlock = false; return; }
-    if (!sceneNodeList) { qCritical() << "BLOCK: sceneNodeList is null!"; sendBlock = false; return; }
-    if (!_globalTimer)  { qCritical() << "BLOCK: _globalTimer is null!";  sendBlock = false; return; }
-
-    qDebug() << "BLOCK: animData bones:" << animData->mBones.size()
-             << "| charObj sceneObjectID:" << charObj->sceneObjectID
-             << "| sceneNodeList size:" << sceneNodeList->mSceneNodeObjectSequence.size()
-             << "| skinnedMeshList size:" << charObj->skinnedMeshList.size()
-             << "| skeletonObjIDs size:" << charObj->skeletonObjIDs.size();
-
     QByteArray* msgBodyAnim = new QByteArray();
 
     bool locked = false;
 
     m_pauseMutex.lock();
 
-    qDebug() << "BLOCK: calling SerializeAnimation...";
     mutex.lock();
     SerializeAnimation(animData, charObj, sceneNodeList, msgBodyAnim, 0);
     mutex.unlock();
-    qDebug() << "BLOCK: SerializeAnimation done, msgBodyAnim size:" << msgBodyAnim->size();
 
-    if (dumpMessageToFile) {
-        QString dumpPath = QCoreApplication::applicationDirPath() + "/animhost_animation_dump.json";
-        dumpAnimationToJson(animData, charObj, sceneNodeList, dumpPath);
-        dumpMessageToFile = false;
-    }
-
-    qDebug() << "BLOCK: calling createNewMessage...";
     createNewMessage( _globalTimer->getLocalTimeStamp(), ZMQMessageHandler::MessageType::PARAMETERUPDATE, msgBodyAnim);
-    qDebug() << "BLOCK: createNewMessage done";
 
     // Sending LOCK message to the character (necessary for applying root animations)
     if (!locked) {
-        qDebug() << "BLOCK: sending LOCK message for sceneObjectID:" << charObj->sceneObjectID;
         createLockMessage(_globalTimer->getLocalTimeStamp(), charObj->sceneObjectID, true);
         int retunLockVal = sendSocket->send((void*)lockMessage->data(), lockMessage->size());
-        qDebug() << "BLOCK: LOCK send returned:" << retunLockVal;
         locked = true;
     }
 
     // Sending new parameter update message
-    qDebug() << "BLOCK: sending PARAMETERUPDATE message, size:" << message->size();
     int retunVal = sendSocket->send((void*)message->data(), message->size());
-    qDebug() << "BLOCK: PARAMETERUPDATE send returned:" << retunVal;
 
     QThread::msleep(1);
 
     m_pauseMutex.unlock();
 
     //UNLOCK CHARACTER
-    qDebug() << "BLOCK: sending UNLOCK message";
     createLockMessage(_globalTimer->getLocalTimeStamp(), charObj->sceneObjectID, false);
     int retunUnlockVal = sendSocket->send((void*)lockMessage->data(), lockMessage->size());
-    qDebug() << "BLOCK: UNLOCK send returned:" << retunUnlockVal;
     locked = false;
 
     // Set _working to false -> process cannot be aborted anymore
     mutex.lock();
     sendBlock = false;
     mutex.unlock();
-
-    qDebug() << "BLOCK: sendAnimationDataBlock complete";
 }
 
 
@@ -536,215 +498,6 @@ void AnimHostMessageSender::SerializeAnimation(std::shared_ptr<Animation> animDa
     }
 
 }
-
-void AnimHostMessageSender::dumpPoseToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
-                                           std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, int frame, const QString& path) {
-    QJsonObject root;
-    root["messageType"] = "PARAMETERUPDATE";
-    root["mode"] = "pose";
-    root["frame"] = frame;
-    root["targetSceneID"] = (int)ZMQMessageHandler::getTargetSceneID();
-    root["characterObjectID"] = (int)character->sceneObjectID;
-
-    // Resolve bone map
-    std::vector<int> skeletonFallback;
-    const std::vector<int>* boneMapPtr = nullptr;
-    if (!character->skinnedMeshList.empty()) {
-        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
-        root["boneMapSource"] = "skinnedMesh";
-    } else if (character->skeletonObjIDs.size() > 1) {
-        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
-        boneMapPtr = &skeletonFallback;
-        root["boneMapSource"] = "skeletonFallback";
-    } else {
-        root["error"] = "no bone map available";
-        QFile file(path);
-        file.open(QIODevice::WriteOnly);
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-        return;
-    }
-    const std::vector<int>& boneMapIDs = *boneMapPtr;
-    int nBones = (int)boneMapIDs.size();
-    root["nBones"] = nBones;
-
-    // Root transform
-    glm::quat rootQuat = animData->mBones.at(0).GetOrientation(frame);
-    glm::vec3 rootPos = animData->mBones.at(0).GetPosition(frame);
-    QJsonObject rootTransform;
-    rootTransform["position"] = QJsonObject{{"x", rootPos.x}, {"y", rootPos.y}, {"z", rootPos.z}};
-    rootTransform["rotation"] = QJsonObject{{"x", rootQuat.x}, {"y", rootQuat.y}, {"z", rootQuat.z}, {"w", rootQuat.w}};
-    rootTransform["paramID_pos"] = 0;
-    rootTransform["paramID_rot"] = 1;
-    root["root"] = rootTransform;
-
-    // Bones
-    QJsonArray bonesArray;
-    for (int i = 0; i < nBones; i++) {
-        int boneID = boneMapIDs.at(i);
-        if (boneID < 0 || boneID >= (int)sceneNodeList->mSceneNodeObjectSequence.size()) continue;
-        std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
-        if (boneName == "heel_02_R" || boneName == "heel_02_L") continue;
-
-        int animDataBoneID = -1;
-        for (int j = 0; j < (int)animData->mBones.size(); j++) {
-            if (boneName == animData->mBones.at(j).mName) { animDataBoneID = j; break; }
-        }
-        if (animDataBoneID < 0) continue;
-
-        glm::quat boneQuat = animData->mBones.at(animDataBoneID).GetOrientation(frame);
-        glm::vec3 bonePos = animData->mBones.at(animDataBoneID).GetPosition(frame);
-
-        QJsonObject boneObj;
-        boneObj["index"] = i;
-        boneObj["boneID"] = boneID;
-        boneObj["boneName"] = QString::fromStdString(boneName);
-        boneObj["animDataBoneID"] = animDataBoneID;
-        boneObj["paramID_rot"] = i + 3 + 3;
-        boneObj["paramID_pos"] = i + nBones + 3 + 3;
-        boneObj["rotation"] = QJsonObject{{"x", boneQuat.x}, {"y", boneQuat.y}, {"z", boneQuat.z}, {"w", boneQuat.w}};
-        boneObj["position"] = QJsonObject{{"x", bonePos.x}, {"y", bonePos.y}, {"z", bonePos.z}};
-        bonesArray.append(boneObj);
-    }
-    root["bones"] = bonesArray;
-
-    QFile file(path);
-    if (file.open(QIODevice::WriteOnly)) {
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-        qDebug() << "Pose dump written to:" << path;
-    } else {
-        qWarning() << "Failed to open dump file:" << path;
-    }
-}
-
-void AnimHostMessageSender::dumpAnimationToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
-                                                std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, const QString& path) {
-    QJsonObject root;
-    root["messageType"] = "PARAMETERUPDATE";
-    root["mode"] = "animation";
-    root["targetSceneID"] = (int)ZMQMessageHandler::getTargetSceneID();
-    root["characterObjectID"] = (int)character->sceneObjectID;
-
-    if (animData->mBones.empty()) {
-        root["error"] = "no bones in animation data";
-        QFile file(path);
-        file.open(QIODevice::WriteOnly);
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-        return;
-    }
-
-    // Resolve bone map
-    std::vector<int> skeletonFallback;
-    const std::vector<int>* boneMapPtr = nullptr;
-    if (!character->skinnedMeshList.empty()) {
-        boneMapPtr = &character->skinnedMeshList.at(0).boneMapIDs;
-        root["boneMapSource"] = "skinnedMesh";
-    } else if (character->skeletonObjIDs.size() > 1) {
-        skeletonFallback.assign(character->skeletonObjIDs.begin() + 1, character->skeletonObjIDs.end());
-        boneMapPtr = &skeletonFallback;
-        root["boneMapSource"] = "skeletonFallback";
-    } else {
-        root["error"] = "no bone map available";
-        QFile file(path);
-        file.open(QIODevice::WriteOnly);
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-        return;
-    }
-    const std::vector<int>& boneMapIDs = *boneMapPtr;
-    int nBones = (int)boneMapIDs.size();
-    root["nBones"] = nBones;
-    root["animBoneCount"] = (int)animData->mBones.size();
-
-    // Root keyframes
-    QJsonObject rootObj;
-    rootObj["paramID_pos"] = 0;
-    rootObj["paramID_rot"] = 1;
-
-    auto& rootBone = animData->mBones.at(0);
-    rootObj["positionKeyCount"] = (int)rootBone.mPositonKeys.size();
-    rootObj["rotationKeyCount"] = (int)rootBone.mRotationKeys.size();
-
-    // Root position keyframes (limit to first 5 + last for readability)
-    QJsonArray rootPosKeys;
-    for (int k = 0; k < (int)rootBone.mPositonKeys.size(); k++) {
-        auto& key = rootBone.mPositonKeys.at(k);
-        QJsonObject kObj;
-        kObj["time_s"] = key.timeStamp / 60.0;
-        kObj["position"] = QJsonObject{{"x", key.position.x}, {"y", key.position.y}, {"z", key.position.z}};
-        rootPosKeys.append(kObj);
-    }
-    rootObj["positionKeys"] = rootPosKeys;
-
-    QJsonArray rootRotKeys;
-    for (int k = 0; k < (int)rootBone.mRotationKeys.size(); k++) {
-        auto& key = rootBone.mRotationKeys.at(k);
-        QJsonObject kObj;
-        kObj["time_s"] = key.timeStamp / 60.0;
-        kObj["rotation"] = QJsonObject{{"x", key.orientation.x}, {"y", key.orientation.y}, {"z", key.orientation.z}, {"w", key.orientation.w}};
-        rootRotKeys.append(kObj);
-    }
-    rootObj["rotationKeys"] = rootRotKeys;
-    root["root"] = rootObj;
-
-    // Bones
-    QJsonArray bonesArray;
-    for (int i = 0; i < nBones; i++) {
-        int boneID = boneMapIDs.at(i);
-        if (boneID < 0 || boneID >= (int)sceneNodeList->mSceneNodeObjectSequence.size()) continue;
-        std::string boneName = sceneNodeList->mSceneNodeObjectSequence.at(boneID).objectName;
-        if (boneName == "heel_02_R" || boneName == "heel_02_L") continue;
-
-        int animDataBoneID = -1;
-        for (int j = 0; j < (int)animData->mBones.size(); j++) {
-            if (boneName == animData->mBones.at(j).mName) { animDataBoneID = j; break; }
-        }
-        if (animDataBoneID < 0) continue;
-
-        QJsonObject boneObj;
-        boneObj["index"] = i;
-        boneObj["boneID"] = boneID;
-        boneObj["boneName"] = QString::fromStdString(boneName);
-        boneObj["animDataBoneID"] = animDataBoneID;
-        boneObj["paramID_rot"] = i + 3 + 3;
-        boneObj["paramID_pos"] = i + nBones + 3 + 3;
-
-        auto& bone = animData->mBones.at(animDataBoneID);
-        boneObj["positionKeyCount"] = (int)bone.mPositonKeys.size();
-        boneObj["rotationKeyCount"] = (int)bone.mRotationKeys.size();
-
-        // Include all keyframes
-        if (!bone.mPositonKeys.empty()) {
-            QJsonArray posKeys;
-            for (auto& key : bone.mPositonKeys) {
-                QJsonObject kObj;
-                kObj["time_s"] = key.timeStamp / 60.0;
-                kObj["position"] = QJsonObject{{"x", key.position.x}, {"y", key.position.y}, {"z", key.position.z}};
-                posKeys.append(kObj);
-            }
-            boneObj["positionKeys"] = posKeys;
-        }
-
-        QJsonArray rotKeys;
-        for (auto& key : bone.mRotationKeys) {
-            QJsonObject kObj;
-            kObj["time_s"] = key.timeStamp / 60.0;
-            kObj["rotation"] = QJsonObject{{"x", key.orientation.x}, {"y", key.orientation.y}, {"z", key.orientation.z}, {"w", key.orientation.w}};
-            rotKeys.append(kObj);
-        }
-        boneObj["rotationKeys"] = rotKeys;
-
-        bonesArray.append(boneObj);
-    }
-    root["bones"] = bonesArray;
-
-    QFile file(path);
-    if (file.open(QIODevice::WriteOnly)) {
-        file.write(QJsonDocument(root).toJson(QJsonDocument::Indented));
-        qDebug() << "Animation dump written to:" << path;
-    } else {
-        qWarning() << "Failed to open dump file:" << path;
-    }
-}
-
 
 // Creating ZMQ Parameter Update Message Body from T value
 template<typename T>

--- a/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.h
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.h
@@ -42,6 +42,9 @@
 #include <QMutex>
 #include <QMultiMap>
 #include <QElapsedTimer>
+#include <QJsonDocument>
+#include <QJsonObject>
+#include <QJsonArray>
 //#include <nzmqt/nzmqt.hpp>
 #include <zmq.hpp>
 
@@ -177,8 +180,16 @@ class TRACERPLUGINSHARED_EXPORT AnimHostMessageSender : public ZMQMessageHandler
     void SerializePose(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
                        std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, QByteArray* byteArray, int frame = 0);
 
-    void SerializeAnimation(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character, 
+    void SerializeAnimation(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
                                 std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, QByteArray* byteArray, int frame);
+
+    void dumpPoseToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
+                        std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, int frame, const QString& path);
+
+    void dumpAnimationToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
+                             std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, const QString& path);
+
+    void setDumpMessage() { dumpMessageToFile = true; }
 
     //! Indicates whether the sent animation will loop or not
     /*!
@@ -190,6 +201,8 @@ class TRACERPLUGINSHARED_EXPORT AnimHostMessageSender : public ZMQMessageHandler
     bool streamAnimation = false; //!< Indicates whether the animation data has to be streamed frame by frame or send en bloc
 
     bool sendBlock = false; //!< Indicates whether the animation data has to be sent en bloc
+
+    bool dumpMessageToFile = true; //!< One-shot flag to dump the next message to a JSON file
 
 	bool targetAddressChanged = false; //!< Indicates whether the target address has been changed
 

--- a/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.h
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/AnimationSender/AnimHostMessageSender.h
@@ -42,9 +42,6 @@
 #include <QMutex>
 #include <QMultiMap>
 #include <QElapsedTimer>
-#include <QJsonDocument>
-#include <QJsonObject>
-#include <QJsonArray>
 //#include <nzmqt/nzmqt.hpp>
 #include <zmq.hpp>
 
@@ -183,14 +180,6 @@ class TRACERPLUGINSHARED_EXPORT AnimHostMessageSender : public ZMQMessageHandler
     void SerializeAnimation(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
                                 std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, QByteArray* byteArray, int frame);
 
-    void dumpPoseToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
-                        std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, int frame, const QString& path);
-
-    void dumpAnimationToJson(std::shared_ptr<Animation> animData, std::shared_ptr<CharacterObject> character,
-                             std::shared_ptr<SceneNodeObjectSequence> sceneNodeList, const QString& path);
-
-    void setDumpMessage() { dumpMessageToFile = true; }
-
     //! Indicates whether the sent animation will loop or not
     /*!
     * Is modified through the Qt Application UI.
@@ -201,8 +190,6 @@ class TRACERPLUGINSHARED_EXPORT AnimHostMessageSender : public ZMQMessageHandler
     bool streamAnimation = false; //!< Indicates whether the animation data has to be streamed frame by frame or send en bloc
 
     bool sendBlock = false; //!< Indicates whether the animation data has to be sent en bloc
-
-    bool dumpMessageToFile = true; //!< One-shot flag to dump the next message to a JSON file
 
 	bool targetAddressChanged = false; //!< Indicates whether the target address has been changed
 

--- a/AnimHost/animHost_Plugins/TRACERPlugin/ControlPathDecoder/ControlPathDecoder.cpp
+++ b/AnimHost/animHost_Plugins/TRACERPlugin/ControlPathDecoder/ControlPathDecoder.cpp
@@ -157,7 +157,7 @@ void ControlPathDecoderNode::run()
 
         //Construct the path
         for (int i = 0; i < this->_pointLocation.size() - 1; i++) {
-            qDebug() << "Processing Control Point" << i;
+            qDebug() << "Processing Control Segment starting at" << i;
             glm::vec3   thisLoc = this->_pointLocation.at(i).value;
             glm::vec3   outTang = this->_pointLocation.at(i).outTangentValue;
             int         firstFrame = this->_pointLocation.at(i).time;

--- a/INFERENCE.md
+++ b/INFERENCE.md
@@ -68,12 +68,12 @@ cd .\DataHub\DataHub\
 
 | Parameter | Range | Default | Description |
 |-----------|-------|---------|-------------|
-| **Mix Root Rotation** | 0.0 - 1.0 | 0.5 | Root rotation blend (0 = network, 1 = path) |
-| **Mix Root Translation** | 0.0 - 1.0 | 0.5 | Root position blend (0 = network, 1 = path) |
-| **Path Position Influence** | 0.0 - 1.0 | 0.5 | Pre-inference position blend (0 = strict path, 1 = loose) |
-| **Path Rotation Influence** | 0.0 - 1.0 | 0.3 | Pre-inference rotation blend (0 = strict path, 1 = loose) |
-| **Network Phase Bias** | 0 - 100 | 50 | Post-inference phase blend (0 = steady gait, 100 = fast tempo adaptation) |
-| **Network Control Bias** | 0 - 100 | 33 | Post-inference trajectory blend (0 = ignore network, 100 = trust network) |
+| **Mix Root Rotation** | 0.0 - 1.0 | 0.0 | Root rotation blend (0 = network, 1 = control path) |
+| **Mix Root Translation** | 0.0 - 1.0 | 0.0 | Root position blend (0 = network, 1 = control path) |
+| **Path Position Influence** | 0.0 - 1.0 | 0.5 | Control position blend (0 = strict control path, 1 = loose) |
+| **Path Rotation Influence** | 0.0 - 1.0 | 0.3 | Control rotation blend (0 = strict control path, 1 = loose) |
+| **Network Phase Bias** | 0 - 100 | 50 | Network feedback phase blend (0 = steady gait, 100 = fast tempo adaptation) |
+| **Network Control Bias** | 0 - 100 | 33 | Network feedback blend (0 = ignore network, 100 = trust network) |
 
 > **Note:** Settings of 0, 0, 1, 1, 100, 100 produce output closest to raw network predictions.
 

--- a/TestScenes/InferencePipeline.flow
+++ b/TestScenes/InferencePipeline.flow
@@ -174,12 +174,12 @@
             "id": 3,
             "internal-data": {
                 "fileSelection": "../../../../Users/m5940/Desktop/DEMO_Package/ResourcesAnimHost/GNN_2025_01_30_Eddy_NoMirror_E290.onnx",
-                "mixControlPathRotation": 1.0,
-                "mixControlPathTranslation": 1.0,
+                "mixControlPathRotation": 0.3,
+                "mixControlPathTranslation": 0.5,
                 "mixRootRotation": 0.0,
                 "mixRootTranslation": 0.0,
                 "model-name": "GNNNode",
-                "networkControlBias": 1.0,
+                "networkControlBias": 0.33,
                 "networkPhaseBias": 0.5
             },
             "position": {

--- a/TestScenes/InferencePipeline.flow
+++ b/TestScenes/InferencePipeline.flow
@@ -174,12 +174,12 @@
             "id": 3,
             "internal-data": {
                 "fileSelection": "../../../../Users/m5940/Desktop/DEMO_Package/ResourcesAnimHost/GNN_2025_01_30_Eddy_NoMirror_E290.onnx",
-                "mixControlPathRotation": 0.3,
-                "mixControlPathTranslation": 0.5,
-                "mixRootRotation": 0.5,
-                "mixRootTranslation": 0.5,
+                "mixControlPathRotation": 1.0,
+                "mixControlPathTranslation": 1.0,
+                "mixRootRotation": 0.0,
+                "mixRootTranslation": 0.0,
                 "model-name": "GNNNode",
-                "networkControlBias": 0.33000001311302185,
+                "networkControlBias": 1.0,
                 "networkPhaseBias": 0.5
             },
             "position": {

--- a/python/scripts/analyze_gnn_data.py
+++ b/python/scripts/analyze_gnn_data.py
@@ -1,0 +1,1115 @@
+"""
+GNN Input Data Analyzer
+
+Loads two GNN Input.bin datasets (baseline + candidate) and supports
+various comparison modes.
+
+Data format:
+  - Input.bin      : flat float32 array, shape from InputShape.txt
+  - InputShape.txt : line 1 = num_samples, line 2 = num_features
+  - InputLabels.txt: one line per feature, format "[idx] label_name"
+"""
+
+from __future__ import annotations
+
+import math
+import re
+import struct
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# Unity
+BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-2\GNN Data A"
+
+# AnimHost
+CANDIDATE_DIR = r"D:\anim-ws\AnimHost\build\Release\artifacts\jaspe_20260305_10\GNN\Data"
+
+MODE = "compute_bone_corrections"  # "coordinates" | "baseline_coordinates" | "candidate_coordinates" | "speed" | "root_output" | "input_skeleton" | "input_skeleton_rot_check" | "input_skeleton_speed_check" | "compute_bone_corrections"
+
+
+BASELINE_COORD_SCALE = 1  # baseline coordinates are normalised (×100 = metres), candidate already in metres
+CANDIDATE_SPEED_MULTIPLIER = 100
+
+# ── Coordinate mode config ────────────────────────────────────────────────────
+# Data index: 0-based index into the dataset's segments.
+# The user figures out which baseline segment matches which candidate segment.
+BASELINE_DATA_INDEX  = 0
+CANDIDATE_DATA_INDEX = 0
+
+# Row slicing (None = no limit). Applied after segment selection.
+BASELINE_SLICE  = (60, 1060)   # (start, end) or None for all rows
+CANDIDATE_SLICE = (0, 1000)   # (start, end) or None for all rows
+
+# Labels for the 2D coordinates to plot (X, Y from each dataset)
+BASELINE_X_LABEL  = "TrajectoryPosition7X"
+BASELINE_Y_LABEL  = "TrajectoryPosition7Z"
+CANDIDATE_X_LABEL = "root_pos_x_6"
+CANDIDATE_Y_LABEL = "root_pos_y_6"
+
+# ── Speed mode config ──────────────────────────────────────────────────────────
+BASELINE_SPEED_LABEL  = "Actions7-3"
+CANDIDATE_SPEED_LABEL = "root_speed_6"
+
+# ── Root output mode config ────────────────────────────────────────────────────
+# Baseline Output.bin lives in BASELINE_DIR alongside Input.bin.
+# Each tuple: (baseline_label, candidate_label, row_title, b_scale, c_scale)
+#   b_scale / c_scale are multiplied before plotting so both columns share the same unit.
+#   Translation: baseline is in normalised units (×100 = metres), candidate already in metres.
+#   Rotation:    baseline is in degrees, candidate is in radians → c_scale = 180/π → both degrees.
+ROOT_OUTPUT_PAIRS = [
+    ("RootUpdateX", "delta_x",     "X translation delta  (m)",   1.0,           1.0),
+    ("RootUpdateY", "delta_angle", "Y rotation delta  (deg)",       1.0, 180.0/math.pi),
+    ("RootUpdateZ", "delta_y",     "Z translation delta  (m)",   1.0,           1.0),
+]
+
+# ── Skeleton mode config ──────────────────────────────────────────────────────
+# Each tuple: (baseline_prefix, candidate_bone_name)
+#   baseline_prefix     : full prefix in baseline labels, e.g. "Bone1Hips"
+#   candidate_bone_name : bone name used in candidate labels, e.g. "Hips"
+# Baseline label pattern : {prefix}PositionX/Y/Z, {prefix}ForwardX/Y/Z,
+#                          {prefix}UpX/Y/Z, {prefix}VelocityX/Y/Z
+# Candidate label pattern: jpos_x/y/z_{bone}, jrot_0..5_{bone}, jvel_x/y/z_{bone}
+SKELETON_BONES = [
+    ("Bone18Head", "Head"),
+]
+SKEL_POS_B_SCALE = 100.0   # baseline position: normalised → metres
+SKEL_VEL_B_SCALE = 1.0     # baseline velocity: same unit as candidate (both cm/s)
+
+# ── Skeleton check mode config ────────────────────────────────────────────────
+# Auto-discovers all bones from baseline labels. No manual SKELETON_BONES needed.
+SKEL_CHECK_SPEED_ZERO_THRESH = 0.5   # baseline speed (cm/s) below which a bone is "zero-speed"
+
+# ── Bone correction mode config ────────────────────────────────────────────────
+# Bones whose per-frame variance exceeds this threshold are flagged UNRELIABLE.
+# The C# output uses Quaternion.identity for them; handle separately (lock to parent / skip).
+CORRECTION_VARIANCE_THRESH_DEG = 10.0
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _read_shape(directory: Path) -> tuple[int, int]:
+    """Read (num_samples, num_features) from InputShape.txt."""
+    text = (directory / "InputShape.txt").read_text(encoding="utf-8")
+    lines = text.strip().splitlines()
+    return int(lines[0]), int(lines[1])
+
+
+def _read_labels(directory: Path) -> list[str]:
+    """Read feature labels from InputLabels.txt.  Format: '[idx] label_name'."""
+    labels: list[str] = []
+    with open(directory / "InputLabels.txt", "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            # "[0] RootX" -> "RootX"
+            if line.startswith("["):
+                label = line.split("]", 1)[1].strip()
+            else:
+                label = line
+            labels.append(label)
+    return labels
+
+
+def _read_binary(path: Path, num_samples: int, num_features: int) -> np.ndarray:
+    """Read float32 Input.bin into (num_samples, num_features) array."""
+    expected_bytes = num_samples * num_features * 4
+    raw = path.read_bytes()
+    if len(raw) < expected_bytes:
+        raise EOFError(
+            f"Input.bin too small: expected {expected_bytes} bytes "
+            f"({num_samples}×{num_features}×4), got {len(raw)}"
+        )
+    return np.frombuffer(raw[:expected_bytes], dtype=np.float32).reshape(
+        num_samples, num_features
+    )
+
+
+def _label_to_col(labels: list[str], name: str) -> int:
+    """Find column index for a label name. Raises ValueError if not found."""
+    for i, lbl in enumerate(labels):
+        if lbl == name:
+            return i
+    raise ValueError(
+        f"Label '{name}' not found. Available labels:\n"
+        + "\n".join(f"  [{i}] {l}" for i, l in enumerate(labels))
+    )
+
+
+def _rot6d_to_matrix(a0: np.ndarray, a1: np.ndarray) -> np.ndarray:
+    """Gram-Schmidt 6D → rotation matrix.
+
+    a0, a1: (N, 3) — first two COLUMN vectors of the rotation matrix
+                      (col0 = Right/X, col1 = Up/Y).
+    Returns (N, 3, 3) with columns [Right, Up, Forward].
+    Used for candidate (AnimHost/GLM convention).
+    """
+    b0 = a0 / np.linalg.norm(a0, axis=-1, keepdims=True)
+    b1 = a1 - np.sum(a1 * b0, axis=-1, keepdims=True) * b0
+    b1 = b1 / np.linalg.norm(b1, axis=-1, keepdims=True)
+    b2 = np.cross(b0, b1)
+    return np.stack([b0, b1, b2], axis=-1)  # (N, 3, 3)
+
+
+def _fwd_up_to_matrix(fwd: np.ndarray, up: np.ndarray) -> np.ndarray:
+    """Build rotation matrix from Forward (col2) + Up (col1) vectors.
+
+    Baseline (Unity/AI4Animation) convention: Forward = local-Z (col2),
+    Up = local-Y (col1).  Unity is LEFT-handed, so Right = Forward × Up
+    (left-hand cross product rule, same as standard math formula but yields
+    +X when Forward=+Z and Up=+Y in a left-handed frame).
+    Returns (N, 3, 3) with columns [Right, Up, Forward] — same layout as
+    _rot6d_to_matrix — so geodesic error is meaningful.
+    """
+    fwd_n = fwd / np.linalg.norm(fwd, axis=-1, keepdims=True)
+    up_n  = up  / np.linalg.norm(up,  axis=-1, keepdims=True)
+    right = np.cross(up_n, fwd_n)                              # col0 = Up × Forward → +X (right-hand)
+    right = right / np.linalg.norm(right, axis=-1, keepdims=True)
+    up_ortho = np.cross(fwd_n, right)                          # re-orthogonalise col1
+    return np.stack([right, up_ortho, fwd_n], axis=-1)         # (N, 3, 3) = [Right, Up, Forward]
+
+
+def _rotation_error_deg(Ra: np.ndarray, Rb: np.ndarray) -> np.ndarray:
+    """Geodesic angular error in degrees between two batches of rotation matrices.
+
+    Ra, Rb: (N, 3, 3). Returns (N,) error in degrees.
+    """
+    R_err = Ra.swapaxes(-2, -1) @ Rb  # R_a^T @ R_b  (N, 3, 3)
+    trace = R_err[..., 0, 0] + R_err[..., 1, 1] + R_err[..., 2, 2]
+    cos_angle = np.clip((trace - 1.0) / 2.0, -1.0, 1.0)
+    return np.degrees(np.arccos(cos_angle))
+
+
+def load_dataset(directory: str) -> tuple[np.ndarray, list[str]]:
+    """Load Input.bin + metadata from a GNN data directory.
+
+    Returns (data array of shape (num_samples, num_features), labels list).
+    """
+    d = Path(directory)
+    num_samples, num_features = _read_shape(d)
+    print(f"  Shape: {num_samples} samples × {num_features} features")
+    data = _read_binary(d / "Input.bin", num_samples, num_features)
+    labels = _read_labels(d)
+    if len(labels) != num_features:
+        print(
+            f"  WARNING: InputLabels.txt has {len(labels)} entries "
+            f"but InputShape.txt says {num_features} features"
+        )
+    return data, labels
+
+
+def _get_segment(data: np.ndarray, segment_index: int) -> np.ndarray:
+    """Return rows for the given segment index.
+
+    Currently treats the entire dataset as segment 0.
+    Extend this if segment boundary information becomes available.
+    """
+    if segment_index != 0:
+        raise ValueError(
+            f"Segment index {segment_index} requested but only segment 0 "
+            "is supported (whole dataset). Segment boundary detection not yet implemented."
+        )
+    return data
+
+
+def load_output_dataset(directory: str) -> tuple[np.ndarray, list[str]]:
+    """Load Output.bin + metadata (OutputShape.txt, OutputLabels.txt)."""
+    d = Path(directory)
+    lines = (d / "OutputShape.txt").read_text(encoding="utf-8").strip().splitlines()
+    num_samples, num_features = int(lines[0]), int(lines[1])
+    print(f"  Shape: {num_samples} samples × {num_features} features")
+    data = _read_binary(d / "Output.bin", num_samples, num_features)
+    labels: list[str] = []
+    with open(d / "OutputLabels.txt", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            label = line.split("]", 1)[1].strip() if line.startswith("[") else line
+            labels.append(label)
+    return data, labels
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+
+def _average_rotations(R_stack: np.ndarray) -> np.ndarray:
+    """Geodesic mean of a batch of rotation matrices via SVD projection.
+
+    R_stack: (N, 3, 3). Returns (3, 3).
+    """
+    M = R_stack.mean(axis=0)
+    U, _, Vt = np.linalg.svd(M)
+    R_mean = U @ Vt
+    if np.linalg.det(R_mean) < 0:
+        U[:, -1] *= -1
+        R_mean = U @ Vt
+    return R_mean
+
+
+def _mat_to_quat_xyzw(R: np.ndarray) -> tuple[float, float, float, float]:
+    """3×3 rotation matrix → quaternion in Unity (x, y, z, w) order."""
+    trace = R[0, 0] + R[1, 1] + R[2, 2]
+    if trace > 0:
+        s = 0.5 / math.sqrt(trace + 1.0)
+        w = 0.25 / s
+        x = (R[2, 1] - R[1, 2]) * s
+        y = (R[0, 2] - R[2, 0]) * s
+        z = (R[1, 0] - R[0, 1]) * s
+    elif R[0, 0] > R[1, 1] and R[0, 0] > R[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + R[0, 0] - R[1, 1] - R[2, 2])
+        w = (R[2, 1] - R[1, 2]) / s
+        x = 0.25 * s
+        y = (R[0, 1] + R[1, 0]) / s
+        z = (R[0, 2] + R[2, 0]) / s
+    elif R[1, 1] > R[2, 2]:
+        s = 2.0 * math.sqrt(1.0 + R[1, 1] - R[0, 0] - R[2, 2])
+        w = (R[0, 2] - R[2, 0]) / s
+        x = (R[0, 1] + R[1, 0]) / s
+        y = 0.25 * s
+        z = (R[1, 2] + R[2, 1]) / s
+    else:
+        s = 2.0 * math.sqrt(1.0 + R[2, 2] - R[0, 0] - R[1, 1])
+        w = (R[1, 0] - R[0, 1]) / s
+        x = (R[0, 2] + R[2, 0]) / s
+        y = (R[1, 2] + R[2, 1]) / s
+        z = 0.25 * s
+    return float(x), float(y), float(z), float(w)
+
+
+# ── Modes ─────────────────────────────────────────────────────────────────────
+
+
+def _plot_trajectory(
+    ax: plt.Axes,
+    x: np.ndarray,
+    y: np.ndarray,
+    tag: str,
+    color: str,
+) -> None:
+    """Plot a single 2D trajectory with start/end markers."""
+    ax.plot(x, y, "o-", color=color, markersize=2, lw=0.8, alpha=0.8, label=tag)
+    ax.plot(x[0], y[0], "s", color=color, markersize=8, label=f"{tag} start")
+    ax.plot(x[-1], y[-1], "^", color=color, markersize=8, label=f"{tag} end")
+
+
+def _print_coord_stats(tag: str, xs: np.ndarray, ys: np.ndarray) -> None:
+    print(f"  {tag}:")
+    print(f"    X  range [{xs.min():.4f}, {xs.max():.4f}]  mean {xs.mean():.4f}")
+    print(f"    Y  range [{ys.min():.4f}, {ys.max():.4f}]  mean {ys.mean():.4f}")
+
+
+def _extract_coords(
+    directory: str,
+    data_index: int,
+    x_label: str,
+    y_label: str,
+    tag: str,
+    row_slice: tuple[int, int] | None = None,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Load dataset, resolve labels, extract segment, optionally slice rows, return (x, y) arrays."""
+    print(f"Loading {tag:10}: {directory}")
+    data, labels = load_dataset(directory)
+    col_x = _label_to_col(labels, x_label)
+    col_y = _label_to_col(labels, y_label)
+    print(f"  {tag} X=[{col_x}] {x_label}  Y=[{col_y}] {y_label}")
+    seg = _get_segment(data, data_index)
+    if row_slice is not None:
+        seg = seg[row_slice[0]:row_slice[1]]
+        print(f"  {tag} : {len(seg)} frames (sliced [{row_slice[0]}:{row_slice[1]}])")
+    else:
+        print(f"  {tag} : {len(seg)} frames")
+    return seg[:, col_x], seg[:, col_y]
+
+
+def mode_coordinates(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    baseline_x_label: str,
+    baseline_y_label: str,
+    candidate_x_label: str,
+    candidate_y_label: str,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Plot 2D coordinates from baseline and candidate for a given segment."""
+    b_x, b_y = _extract_coords(baseline_dir, baseline_data_index, baseline_x_label, baseline_y_label, "baseline", baseline_slice)
+    c_x, c_y = _extract_coords(candidate_dir, candidate_data_index, candidate_x_label, candidate_y_label, "candidate", candidate_slice)
+
+    # Scale baseline coords to match candidate coordinate system
+    b_x = b_x * BASELINE_COORD_SCALE
+    b_y = b_y * BASELINE_COORD_SCALE
+
+    print(f"\n── Coordinate Stats (baseline ×100) {'─' * 40}")
+    _print_coord_stats("Baseline", b_x, b_y)
+    _print_coord_stats("Candidate", c_x, c_y)
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    fig.suptitle("GNN Input — 2D Coordinate Comparison (baseline ×100)", fontsize=12)
+
+    _plot_trajectory(ax, b_x, b_y, "baseline", "tab:blue")
+    _plot_trajectory(ax, c_x, c_y, "candidate", "tab:orange")
+
+    ax.set_xlabel(f"X  (B: {baseline_x_label} / C: {candidate_x_label})")
+    ax.set_ylabel(f"Y  (B: {baseline_y_label} / C: {candidate_y_label})")
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+    ax.legend(fontsize=9)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_baseline_coordinates(
+    baseline_dir: str,
+    baseline_data_index: int,
+    baseline_x_label: str,
+    baseline_y_label: str,
+    baseline_slice: tuple[int, int] | None = None,
+) -> None:
+    """Plot 2D coordinates from baseline only."""
+    b_x, b_y = _extract_coords(baseline_dir, baseline_data_index, baseline_x_label, baseline_y_label, "baseline", baseline_slice)
+
+    print(f"\n── Coordinate Stats {'─' * 50}")
+    _print_coord_stats("Baseline", b_x, b_y)
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    fig.suptitle("GNN Input — Baseline 2D Coordinates", fontsize=12)
+
+    _plot_trajectory(ax, b_x, b_y, "baseline", "tab:blue")
+
+    ax.set_xlabel(baseline_x_label)
+    ax.set_ylabel(baseline_y_label)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+    ax.legend(fontsize=9)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_candidate_coordinates(
+    candidate_dir: str,
+    candidate_data_index: int,
+    candidate_x_label: str,
+    candidate_y_label: str,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Plot 2D coordinates from candidate only."""
+    c_x, c_y = _extract_coords(candidate_dir, candidate_data_index, candidate_x_label, candidate_y_label, "candidate", candidate_slice)
+
+    print(f"\n── Coordinate Stats {'─' * 50}")
+    _print_coord_stats("Candidate", c_x, c_y)
+
+    fig, ax = plt.subplots(figsize=(10, 10))
+    fig.suptitle("GNN Input — Candidate 2D Coordinates", fontsize=12)
+
+    _plot_trajectory(ax, c_x, c_y, "candidate", "tab:orange")
+
+    ax.set_xlabel(candidate_x_label)
+    ax.set_ylabel(candidate_y_label)
+    ax.set_aspect("equal")
+    ax.grid(True, alpha=0.25)
+    ax.legend(fontsize=9)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_speed(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    baseline_speed_label: str,
+    candidate_speed_label: str,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Plot speed over sample index for baseline and candidate."""
+    print(f"Loading baseline : {baseline_dir}")
+    b_data, b_labels = load_dataset(baseline_dir)
+    b_col = _label_to_col(b_labels, baseline_speed_label)
+    print(f"  baseline speed=[{b_col}] {baseline_speed_label}")
+    b_seg = _get_segment(b_data, baseline_data_index)
+    if baseline_slice is not None:
+        b_seg = b_seg[baseline_slice[0]:baseline_slice[1]]
+        print(f"  baseline: {len(b_seg)} frames (sliced [{baseline_slice[0]}:{baseline_slice[1]}])")
+    else:
+        print(f"  baseline: {len(b_seg)} frames")
+    b_speed = b_seg[:, b_col]
+
+    print(f"Loading candidate: {candidate_dir}")
+    c_data, c_labels = load_dataset(candidate_dir)
+    c_col = _label_to_col(c_labels, candidate_speed_label)
+    print(f"  candidate speed=[{c_col}] {candidate_speed_label}")
+    c_seg = _get_segment(c_data, candidate_data_index)
+    if candidate_slice is not None:
+        c_seg = c_seg[candidate_slice[0]:candidate_slice[1]]
+        print(f"  candidate: {len(c_seg)} frames (sliced [{candidate_slice[0]}:{candidate_slice[1]}])")
+    else:
+        print(f"  candidate: {len(c_seg)} frames")
+    c_speed = c_seg[:, c_col] * CANDIDATE_SPEED_MULTIPLIER
+
+    print(f"\n── Speed Stats {'─' * 50}")
+    print(f"  Baseline  range [{b_speed.min():.4f}, {b_speed.max():.4f}]  mean {b_speed.mean():.4f}")
+    print(f"  Candidate range [{c_speed.min():.4f}, {c_speed.max():.4f}]  mean {c_speed.mean():.4f}")
+
+    fig, ax = plt.subplots(figsize=(14, 5))
+    fig.suptitle("GNN Input — Speed Comparison", fontsize=12)
+
+    ax.plot(b_speed, color="tab:blue",   lw=0.9, alpha=0.85, label=f"baseline  ({baseline_speed_label})")
+    ax.plot(c_speed, color="tab:orange", lw=0.9, alpha=0.85, label=f"candidate ({candidate_speed_label})")
+
+    ax.set_xlabel("Sample index")
+    ax.set_ylabel("Speed")
+    ax.grid(True, alpha=0.25)
+    ax.legend(fontsize=9)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_root_output(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    pairs: list[tuple[str, str, str, float, float]],
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Overlay matched root-delta features from baseline and candidate outputs.
+
+    Each pair (baseline_label, candidate_label, title, b_scale, c_scale) describes
+    the same physical quantity.  b_scale / c_scale normalise both columns to the
+    same unit before plotting so the curves can be compared directly.
+    """
+    print(f"Loading baseline output : {baseline_dir}")
+    b_data, b_labels = load_output_dataset(baseline_dir)
+    b_seg = _get_segment(b_data, baseline_data_index)
+    if baseline_slice is not None:
+        b_seg = b_seg[baseline_slice[0]:baseline_slice[1]]
+        print(f"  baseline: {len(b_seg)} frames (sliced [{baseline_slice[0]}:{baseline_slice[1]}])")
+    else:
+        print(f"  baseline: {len(b_seg)} frames")
+
+    print(f"Loading candidate output: {candidate_dir}")
+    c_data, c_labels = load_output_dataset(candidate_dir)
+    c_seg = _get_segment(c_data, candidate_data_index)
+    if candidate_slice is not None:
+        c_seg = c_seg[candidate_slice[0]:candidate_slice[1]]
+        print(f"  candidate: {len(c_seg)} frames (sliced [{candidate_slice[0]}:{candidate_slice[1]}])")
+    else:
+        print(f"  candidate: {len(c_seg)} frames")
+
+    print(f"\n── Root Output Stats {'─' * 40}")
+    b_cols = [(_label_to_col(b_labels, b_lbl), b_lbl) for b_lbl, _, _, _, _ in pairs]
+    c_cols = [(_label_to_col(c_labels, c_lbl), c_lbl) for _, c_lbl, _, _, _ in pairs]
+    for (b_col, b_lbl), (c_col, c_lbl), (_, _, title, b_sc, c_sc) in zip(b_cols, c_cols, pairs):
+        b_vals = b_seg[:, b_col] * b_sc
+        c_vals = c_seg[:, c_col] * c_sc
+        print(f"  {title}")
+        print(f"    baseline  [{b_vals.min():+.4f}, {b_vals.max():+.4f}]  mean {b_vals.mean():+.4f}  ({b_lbl} ×{b_sc})")
+        print(f"    candidate [{c_vals.min():+.4f}, {c_vals.max():+.4f}]  mean {c_vals.mean():+.4f}  ({c_lbl} ×{c_sc})")
+
+    fig, axes = plt.subplots(len(pairs), 1, figsize=(14, 4 * len(pairs)), sharex=True)
+    if len(pairs) == 1:
+        axes = [axes]
+    fig.suptitle("GNN Output — Root Delta: Baseline vs Candidate (unit-normalised)", fontsize=12)
+
+    for ax, (b_col, b_lbl), (c_col, c_lbl), (_, _, title, b_sc, c_sc) in zip(axes, b_cols, c_cols, pairs):
+        b_vals = b_seg[:, b_col] * b_sc
+        c_vals = c_seg[:, c_col] * c_sc
+        ax.plot(b_vals, color="tab:blue",   lw=0.8, alpha=0.85, label=f"baseline  ({b_lbl} ×{b_sc})")
+        ax.plot(c_vals, color="tab:orange", lw=0.8, alpha=0.85, label=f"candidate ({c_lbl} ×{c_sc:.4g})")
+        ax.set_title(title, fontsize=9, loc="left")
+        ax.grid(True, alpha=0.25)
+        ax.legend(fontsize=8)
+
+    axes[-1].set_xlabel("Sample index")
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_input_skeleton(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    bones: list[tuple[str, str]],
+    pos_b_scale: float = 100.0,
+    vel_b_scale: float = 100.0,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Compare skeleton bone data (position, rotation, velocity) per bone.
+
+    For each bone computes:
+      - Position: Euclidean distance after scaling baseline to metres.
+      - Rotation: geodesic angular error in degrees (Gram-Schmidt on both
+                  baseline Forward+Up and candidate col0+col1).
+      - Velocity: Euclidean distance after scaling baseline to m/s.
+
+    Produces 3 figures (one per channel type), each with one subplot per bone.
+    """
+    print(f"Loading baseline : {baseline_dir}")
+    b_data, b_labels = load_dataset(baseline_dir)
+    b_seg = _get_segment(b_data, baseline_data_index)
+    if baseline_slice is not None:
+        b_seg = b_seg[baseline_slice[0]:baseline_slice[1]]
+        print(f"  baseline: {len(b_seg)} frames (sliced [{baseline_slice[0]}:{baseline_slice[1]}])")
+    else:
+        print(f"  baseline: {len(b_seg)} frames")
+
+    print(f"Loading candidate: {candidate_dir}")
+    c_data, c_labels = load_dataset(candidate_dir)
+    c_seg = _get_segment(c_data, candidate_data_index)
+    if candidate_slice is not None:
+        c_seg = c_seg[candidate_slice[0]:candidate_slice[1]]
+        print(f"  candidate: {len(c_seg)} frames (sliced [{candidate_slice[0]}:{candidate_slice[1]}])")
+    else:
+        print(f"  candidate: {len(c_seg)} frames")
+
+    n = min(len(b_seg), len(c_seg))
+    if n < len(b_seg) or n < len(c_seg):
+        print(f"  Trimming to {n} frames (min of both)")
+    b_seg = b_seg[:n]
+    c_seg = c_seg[:n]
+
+    pos_errors: list[np.ndarray] = []
+    rot_errors: list[np.ndarray] = []
+    vel_errors: list[tuple[np.ndarray, np.ndarray]] = []
+    b_pos_list: list[np.ndarray] = []
+    c_pos_list: list[np.ndarray] = []
+    bone_names: list[str] = []
+
+    print(f"\n── Skeleton Stats (pos/vel baseline ×{pos_b_scale}) {'─' * 30}")
+    for b_prefix, c_bone in bones:
+        bone_names.append(c_bone)
+
+        # ── Position ──────────────────────────────────────────────────────────
+        b_pos = np.stack([
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}PositionX")] * pos_b_scale,
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}PositionY")] * pos_b_scale,
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}PositionZ")] * pos_b_scale,
+        ], axis=-1)
+        c_pos = np.stack([
+            c_seg[:, _label_to_col(c_labels, f"jpos_x_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jpos_y_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jpos_z_{c_bone}")],
+        ], axis=-1)
+        pos_err = np.linalg.norm(b_pos - c_pos, axis=-1)
+        pos_errors.append(pos_err)
+        b_pos_list.append(b_pos)
+        c_pos_list.append(c_pos)
+
+        # ── Rotation ──────────────────────────────────────────────────────────
+        # Baseline: Forward (a0) + Up (a1)
+        b_fwd = np.stack([
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardX")],
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardY")],
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardZ")],
+        ], axis=-1)
+        b_up = np.stack([
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpX")],
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpY")],
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpZ")],
+        ], axis=-1)
+        # Candidate: col0/right (a0) + col1/up (a1)
+        c_col0 = np.stack([
+            c_seg[:, _label_to_col(c_labels, f"jrot_0_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jrot_1_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jrot_2_{c_bone}")],
+        ], axis=-1)
+        c_col1 = np.stack([
+            c_seg[:, _label_to_col(c_labels, f"jrot_3_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jrot_4_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jrot_5_{c_bone}")],
+        ], axis=-1)
+        Ra = _fwd_up_to_matrix(b_fwd, b_up)   # Forward=col2, Up=col1 → [Right, Up, Forward]
+        Rc = _rot6d_to_matrix(c_col0, c_col1)  # col0=Right, col1=Up  → [Right, Up, Forward]
+        rot_err = _rotation_error_deg(Ra, Rc)
+        rot_errors.append(rot_err)
+
+        # ── Velocity ──────────────────────────────────────────────────────────
+        b_vel = np.stack([
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityX")] * vel_b_scale,
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityY")] * vel_b_scale,
+            b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityZ")] * vel_b_scale,
+        ], axis=-1)
+        c_vel = np.stack([
+            c_seg[:, _label_to_col(c_labels, f"jvel_x_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jvel_y_{c_bone}")],
+            c_seg[:, _label_to_col(c_labels, f"jvel_z_{c_bone}")],
+        ], axis=-1)
+        b_speed = np.linalg.norm(b_vel, axis=-1)
+        c_speed = np.linalg.norm(c_vel, axis=-1)
+        vel_errors.append((b_speed, c_speed))
+
+        print(f"  {c_bone} ({b_prefix}):")
+        print(f"    pos  (m)     mean {pos_err.mean():.4f}  max {pos_err.max():.4f}")
+        print(f"    rot  (°)     mean {rot_err.mean():.4f}  max {rot_err.max():.4f}")
+        print(f"    speed(B)     mean {b_speed.mean():.4f}  max {b_speed.max():.4f}")
+        print(f"    speed(C)     mean {c_speed.mean():.4f}  max {c_speed.max():.4f}")
+
+    # ── 1 figure: N_bones rows × 5 cols ──────────────────────────────────────
+    # Cols 0-2: position X / Y / Z (baseline vs candidate)
+    # Col 3:    rotation geodesic error
+    # Col 4:    velocity Euclidean error
+    n_bones = len(bones)
+    fig, axes = plt.subplots(
+        n_bones, 5,
+        figsize=(22, 3 * n_bones),
+        sharex=True,
+        squeeze=False,
+    )
+    fig.suptitle("GNN Input — Skeleton Comparison: Baseline vs Candidate", fontsize=12)
+
+    _POS_LABELS = ("X", "Y", "Z")
+    _POS_COLORS = ("tab:red", "tab:green", "tab:blue")
+
+    for row, ((b_prefix, c_bone), b_pos_arr, c_pos_arr, rot_err, (b_speed, c_speed)) in enumerate(
+        zip(bones, b_pos_list, c_pos_list, rot_errors, vel_errors)
+    ):
+        name = c_bone
+
+        # ── Cols 0-2: position X / Y / Z ─────────────────────────────────────
+        for axis_i, (axis_name, color) in enumerate(zip(_POS_LABELS, _POS_COLORS)):
+            ax = axes[row, axis_i]
+            ax.plot(b_pos_arr[:, axis_i], color=color, lw=0.9, alpha=0.9, label="baseline")
+            ax.plot(c_pos_arr[:, axis_i], color=color, lw=0.9, alpha=0.45,
+                    linestyle="--", label="candidate")
+            ax.set_title(f"{name} — pos {axis_name} (m)", fontsize=8, loc="left")
+            ax.set_ylabel("m", fontsize=8)
+            if axis_i == 0:
+                ax.legend(fontsize=7)
+            ax.grid(True, alpha=0.25)
+
+        # ── Col 3: rotation error ─────────────────────────────────────────────
+        ax = axes[row, 3]
+        ax.plot(rot_err, color="tab:purple", lw=0.8, alpha=0.9)
+        ax.set_title(
+            f"{name} — Rotation Error\nmean={rot_err.mean():.2f}°  max={rot_err.max():.2f}°",
+            fontsize=8, loc="left",
+        )
+        ax.set_ylabel("Geodesic angle (°)", fontsize=8)
+        ax.grid(True, alpha=0.25)
+
+        # ── Col 4: speed overlay ──────────────────────────────────────────────
+        ax = axes[row, 4]
+        ax.plot(b_speed, color="tab:blue",   lw=0.9, alpha=0.9, label="baseline")
+        ax.plot(c_speed, color="tab:orange", lw=0.9, alpha=0.75, label="candidate")
+        ax.set_title(
+            f"{name} — Speed\nB mean={b_speed.mean():.3f}  C mean={c_speed.mean():.3f}",
+            fontsize=8, loc="left",
+        )
+        ax.set_ylabel("Speed (cm/s)", fontsize=8)
+        ax.legend(fontsize=7)
+        ax.grid(True, alpha=0.25)
+
+    for col in range(5):
+        axes[-1, col].set_xlabel("Sample index")
+
+    plt.tight_layout()
+    plt.show()
+
+
+def _load_and_trim(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    baseline_slice: tuple[int, int] | None,
+    candidate_slice: tuple[int, int] | None,
+) -> tuple[np.ndarray, list[str], np.ndarray, list[str], list[tuple[str, str]]]:
+    """Shared setup for skeleton check modes: load, slice, trim, discover bones."""
+    print(f"Loading baseline : {baseline_dir}")
+    b_data, b_labels = load_dataset(baseline_dir)
+    b_seg = _get_segment(b_data, baseline_data_index)
+    if baseline_slice is not None:
+        b_seg = b_seg[baseline_slice[0]:baseline_slice[1]]
+        print(f"  baseline: {len(b_seg)} frames (sliced [{baseline_slice[0]}:{baseline_slice[1]}])")
+    else:
+        print(f"  baseline: {len(b_seg)} frames")
+
+    print(f"Loading candidate: {candidate_dir}")
+    c_data, c_labels = load_dataset(candidate_dir)
+    c_seg = _get_segment(c_data, candidate_data_index)
+    if candidate_slice is not None:
+        c_seg = c_seg[candidate_slice[0]:candidate_slice[1]]
+        print(f"  candidate: {len(c_seg)} frames (sliced [{candidate_slice[0]}:{candidate_slice[1]}])")
+    else:
+        print(f"  candidate: {len(c_seg)} frames")
+
+    n = min(len(b_seg), len(c_seg))
+    if n < len(b_seg) or n < len(c_seg):
+        print(f"  Trimming to {n} frames (min of both)")
+    b_seg = b_seg[:n]
+    c_seg = c_seg[:n]
+
+    bones: list[tuple[str, str]] = []
+    for lbl in b_labels:
+        m = re.match(r'(Bone\d+(\w+))PositionX$', lbl)
+        if m:
+            bones.append((m.group(1), m.group(2)))
+    print(f"\n  Auto-discovered {len(bones)} bones from baseline.\n")
+
+    return b_seg, b_labels, c_seg, c_labels, bones
+
+
+def mode_input_skeleton_rot_check(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Auto-discover all bones and report geodesic rotation error per bone.
+
+    Columns: Bone | Rot mean° | Rot min° | Rot max°
+    Bones missing from the candidate are reported as errors and skipped.
+    """
+    b_seg, b_labels, c_seg, c_labels, bones = _load_and_trim(
+        baseline_dir, candidate_dir,
+        baseline_data_index, candidate_data_index,
+        baseline_slice, candidate_slice,
+    )
+
+    W = 18
+    header = (
+        f"{'Bone':<{W}} "
+        f"{'Rot mean°':>10} {'Rot min°':>9} {'Rot max°':>9}"
+    )
+    sep = "─" * len(header)
+    print(header)
+    print(sep)
+
+    missing: list[str] = []
+    for b_prefix, c_bone in bones:
+        try:
+            b_fwd = np.stack([
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardX")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardY")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardZ")],
+            ], axis=-1)
+            b_up = np.stack([
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpX")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpY")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpZ")],
+            ], axis=-1)
+            c_col0 = np.stack([
+                c_seg[:, _label_to_col(c_labels, f"jrot_0_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_1_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_2_{c_bone}")],
+            ], axis=-1)
+            c_col1 = np.stack([
+                c_seg[:, _label_to_col(c_labels, f"jrot_3_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_4_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_5_{c_bone}")],
+            ], axis=-1)
+        except ValueError:
+            missing.append(c_bone)
+            print(f"{'  ' + c_bone:<{W}} {'MISSING IN CANDIDATE':>10}")
+            continue
+
+        Ra = _fwd_up_to_matrix(b_fwd, b_up)
+        Rc = _rot6d_to_matrix(c_col0, c_col1)
+        rot_err = _rotation_error_deg(Ra, Rc)
+        print(f"{c_bone:<{W}} {rot_err.mean():>10.2f} {rot_err.min():>9.2f} {rot_err.max():>9.2f}")
+
+    print(sep)
+    if missing:
+        print(f"\n  Bones missing in candidate ({len(missing)}): {', '.join(missing)}")
+
+
+def mode_input_skeleton_speed_check(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    vel_b_scale: float = 1.0,
+    speed_zero_thresh: float = 0.5,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Auto-discover all bones and report speed stats per bone.
+
+    Columns: Bone | B spd mean | B spd max | B zero? | C spd mean | C spd max
+    B zero? is flagged YES when baseline max speed < speed_zero_thresh.
+    Bones missing from the candidate are reported as errors and skipped.
+    """
+    b_seg, b_labels, c_seg, c_labels, bones = _load_and_trim(
+        baseline_dir, candidate_dir,
+        baseline_data_index, candidate_data_index,
+        baseline_slice, candidate_slice,
+    )
+
+    W = 18
+    header = (
+        f"{'Bone':<{W}} "
+        f"{'B spd mean':>10} {'B spd max':>9} {'B zero?':>7}  "
+        f"{'C spd mean':>10} {'C spd max':>9}"
+    )
+    sep = "─" * len(header)
+    print(header)
+    print(sep)
+
+    missing: list[str] = []
+    for b_prefix, c_bone in bones:
+        try:
+            b_vel = np.stack([
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityX")] * vel_b_scale,
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityY")] * vel_b_scale,
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}VelocityZ")] * vel_b_scale,
+            ], axis=-1)
+            c_vel = np.stack([
+                c_seg[:, _label_to_col(c_labels, f"jvel_x_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jvel_y_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jvel_z_{c_bone}")],
+            ], axis=-1)
+        except ValueError:
+            missing.append(c_bone)
+            print(f"{'  ' + c_bone:<{W}} {'MISSING IN CANDIDATE':>10}")
+            continue
+
+        b_speed = np.linalg.norm(b_vel, axis=-1)
+        c_speed = np.linalg.norm(c_vel, axis=-1)
+        b_zero = b_speed.max() < speed_zero_thresh
+        print(
+            f"{c_bone:<{W}} "
+            f"{b_speed.mean():>10.3f} {b_speed.max():>9.3f} {'YES':>7}  "
+            f"{c_speed.mean():>10.3f} {c_speed.max():>9.3f}"
+            if b_zero else
+            f"{c_bone:<{W}} "
+            f"{b_speed.mean():>10.3f} {b_speed.max():>9.3f} {'---':>7}  "
+            f"{c_speed.mean():>10.3f} {c_speed.max():>9.3f}"
+        )
+
+    print(sep)
+    if missing:
+        print(f"\n  Bones missing in candidate ({len(missing)}): {', '.join(missing)}")
+
+
+def mode_compute_bone_corrections(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_data_index: int,
+    candidate_data_index: int,
+    variance_thresh_deg: float = 10.0,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Compute per-bone correction quaternions: AnimHost bone rotation → Unity bone rotation.
+
+    For each bone, derives R_corr = mean_t(Ra[t]^T @ Rc[t]) — the constant bone-roll offset
+    mapping candidate (AnimHost/Blender) local axes onto baseline (Unity FBX) local axes.
+
+    Application at inference:
+      Feed:  q_animhost_input = q_unity_actor  * Quaternion.Inverse(_boneCorr[i])
+      Read:  q_unity_out      = q_animhost_net * _boneCorr[i]
+
+    Bones with per-frame variance > variance_thresh_deg are UNRELIABLE (Quaternion.identity
+    in the output array). These must be locked to their parent or skipped in Read().
+    """
+    b_seg, b_labels, c_seg, c_labels, bones = _load_and_trim(
+        baseline_dir, candidate_dir,
+        baseline_data_index, candidate_data_index,
+        baseline_slice, candidate_slice,
+    )
+
+    W = 22
+    header = (
+        f"{'Bone':<{W}} "
+        f"{'Corr angle°':>11} {'Var mean°':>9} {'Var max°':>8}  {'Status':>10}"
+    )
+    sep = "─" * len(header)
+    print(header)
+    print(sep)
+
+    # (b_prefix, c_bone, (x,y,z,w), is_reliable)
+    bone_results: list[tuple[str, str, tuple[float, float, float, float], bool]] = []
+
+    eye3 = np.eye(3, dtype=np.float32)[np.newaxis]  # (1,3,3) — identity for angle measure
+
+    for b_prefix, c_bone in bones:
+        try:
+            b_fwd = np.stack([
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardX")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardY")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}ForwardZ")],
+            ], axis=-1)
+            b_up = np.stack([
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpX")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpY")],
+                b_seg[:, _label_to_col(b_labels, f"{b_prefix}UpZ")],
+            ], axis=-1)
+            c_col0 = np.stack([
+                c_seg[:, _label_to_col(c_labels, f"jrot_0_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_1_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_2_{c_bone}")],
+            ], axis=-1)
+            c_col1 = np.stack([
+                c_seg[:, _label_to_col(c_labels, f"jrot_3_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_4_{c_bone}")],
+                c_seg[:, _label_to_col(c_labels, f"jrot_5_{c_bone}")],
+            ], axis=-1)
+        except ValueError:
+            print(f"{'  ' + c_bone:<{W}} {'MISSING IN CANDIDATE':>10}")
+            bone_results.append((b_prefix, c_bone, (0.0, 0.0, 0.0, 1.0), False))
+            continue
+
+        Ra = _fwd_up_to_matrix(b_fwd, b_up)   # (N,3,3)
+        Rc = _rot6d_to_matrix(c_col0, c_col1)  # (N,3,3)
+
+        # Per-frame correction matrix
+        R_corr_frames = Ra.swapaxes(-2, -1) @ Rc  # Ra[t]^T @ Rc[t] → (N,3,3)
+
+        # Mean correction via SVD projection onto SO(3)
+        R_corr_mean = _average_rotations(R_corr_frames)
+
+        # Per-frame variance: geodesic distance from mean
+        R_mean_batch = np.tile(R_corr_mean[np.newaxis], (len(R_corr_frames), 1, 1))
+        var_per_frame = _rotation_error_deg(R_mean_batch, R_corr_frames)
+
+        # Angle of the correction itself (distance from identity)
+        corr_angle = _rotation_error_deg(eye3, R_corr_mean[np.newaxis])[0]
+
+        is_reliable = var_per_frame.mean() <= variance_thresh_deg
+        status = "ok" if is_reliable else "UNRELIABLE"
+
+        q = _mat_to_quat_xyzw(R_corr_mean)
+        bone_results.append((b_prefix, c_bone, q, is_reliable))
+
+        print(
+            f"{c_bone:<{W}} "
+            f"{corr_angle:>11.2f} {var_per_frame.mean():>9.2f} {var_per_frame.max():>8.2f}  "
+            f"{status:>10}"
+        )
+
+    print(sep)
+    unreliable = [c_bone for _, c_bone, _, ok in bone_results if not ok]
+    if unreliable:
+        print(f"\n  UNRELIABLE ({len(unreliable)}): {', '.join(unreliable)}")
+        print(f"  → Quaternion.identity used. Lock to parent or disable in Read().\n")
+
+    # ── C# output ─────────────────────────────────────────────────────────────
+    print()
+    print("// ── Paste into QuadrupedController_GNN_Unified.cs ──────────────────────────────")
+    print("// Bone index order mirrors baseline label discovery (Bone1…BoneN). Verify against")
+    print("// Actor.Bones order before use.")
+    print("// Feed:  NeuralNetwork.Feed((Actor.Bones[i].GetTransform().right).DirectionTo(root * Matrix4x4.Rotate(Quaternion.Inverse(_boneCorr[i]))));")
+    print("// Read:  Quaternion rot = Quaternion.LookRotation(forward, upward) * _boneCorr[i];")
+    print(f"// Variance threshold used: {variance_thresh_deg}°")
+    print("private static readonly Quaternion[] _boneCorr = new Quaternion[]")
+    print("{")
+    for _, c_bone, (x, y, z, w), is_reliable in bone_results:
+        note = "" if is_reliable else "  // UNRELIABLE — lock to parent"
+        print(f"    new Quaternion({x:+.6f}f, {y:+.6f}f, {z:+.6f}f, {w:+.6f}f),  // {c_bone}{note}")
+    print("};")
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    if MODE == "coordinates":
+        mode_coordinates(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            BASELINE_X_LABEL,
+            BASELINE_Y_LABEL,
+            CANDIDATE_X_LABEL,
+            CANDIDATE_Y_LABEL,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "baseline_coordinates":
+        mode_baseline_coordinates(
+            BASELINE_DIR,
+            BASELINE_DATA_INDEX,
+            BASELINE_X_LABEL,
+            BASELINE_Y_LABEL,
+            BASELINE_SLICE,
+        )
+    elif MODE == "candidate_coordinates":
+        mode_candidate_coordinates(
+            CANDIDATE_DIR,
+            CANDIDATE_DATA_INDEX,
+            CANDIDATE_X_LABEL,
+            CANDIDATE_Y_LABEL,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "speed":
+        mode_speed(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            BASELINE_SPEED_LABEL,
+            CANDIDATE_SPEED_LABEL,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "root_output":
+        mode_root_output(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            ROOT_OUTPUT_PAIRS,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "input_skeleton":
+        mode_input_skeleton(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            SKELETON_BONES,
+            SKEL_POS_B_SCALE,
+            SKEL_VEL_B_SCALE,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "input_skeleton_rot_check":
+        mode_input_skeleton_rot_check(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "input_skeleton_speed_check":
+        mode_input_skeleton_speed_check(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            SKEL_VEL_B_SCALE,
+            SKEL_CHECK_SPEED_ZERO_THRESH,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "compute_bone_corrections":
+        mode_compute_bone_corrections(
+            BASELINE_DIR,
+            CANDIDATE_DIR,
+            BASELINE_DATA_INDEX,
+            CANDIDATE_DATA_INDEX,
+            CORRECTION_VARIANCE_THRESH_DEG,
+            BASELINE_SLICE,
+            CANDIDATE_SLICE,
+        )
+    else:
+        print(f"Unknown mode: {MODE}")

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -1,0 +1,269 @@
+"""
+GNN Data Distribution Plotter
+
+Loads a GNN Input.bin or Output.bin dataset and plots the value distribution
+(histogram) for every feature — one plot per feature.
+
+Data format:
+  - Input.bin       : flat float32 array, shape from InputShape.txt
+  - InputShape.txt  : line 1 = num_samples, line 2 = num_features
+  - InputLabels.txt : one line per feature, format "[idx] label_name"
+  - Output.bin / OutputShape.txt / OutputLabels.txt — same layout
+
+Config:
+  DATA_DIR      — path to the GNN data directory
+  DATA_TYPE     — "input" or "output"
+  LABEL_FILTER  — list of label names to plot exclusively; None = plot all
+  BINS          — number of histogram bins
+"""
+
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# COMPARE_MODE: when True, overlay baseline + candidate histograms on the same plots.
+# When False, plot a single dataset as before.
+COMPARE_MODE = True
+
+# Single-dataset config (used when COMPARE_MODE = False)
+DATA_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
+DATA_TYPE = "output"  # "input" | "output"
+
+# Compare-mode config (used when COMPARE_MODE = True)
+BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
+CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"
+COMPARE_DATA_TYPE = "input"  # "input" | "output" (applies to both)
+
+# If non-empty, only these labels are plotted. In compare mode, only labels
+# present in LABEL_FILTER *and* both datasets are shown.
+# LABEL_FILTER: Optional[List[str]] = [
+#     "delta_x", "delta_y", "delta_angle",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "out_root_pos_x_7",  "out_root_pos_y_7",
+#     "out_root_pos_x_8",  "out_root_pos_y_8",
+#     "out_root_pos_x_9",  "out_root_pos_y_9",
+#     "out_root_pos_x_10", "out_root_pos_y_10",
+#     "out_root_pos_x_11", "out_root_pos_y_11",
+#     "out_root_pos_x_12", "out_root_pos_y_12",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "out_jpos_x_hip", "out_jpos_y_hip", "out_jpos_z_hip",
+#     "out_jrot_0_hip", "out_jrot_1_hip", "out_jrot_2_hip",
+#     "out_jrot_3_hip", "out_jrot_4_hip", "out_jrot_5_hip",
+#     "out_jvel_x_hip", "out_jvel_y_hip", "out_jvel_z_hip",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "PhaseUpdate-1",  "PhaseUpdate-2",  "PhaseUpdate-3",  "PhaseUpdate-4",
+#     "PhaseUpdate-5",  "PhaseUpdate-6",  "PhaseUpdate-7",  "PhaseUpdate-8",
+#     "PhaseUpdate-9",  "PhaseUpdate-10", "PhaseUpdate-11", "PhaseUpdate-12",
+# ]
+
+LABEL_FILTER: Optional[List[str]] = [
+    "root_pos_x_7", "root_pos_y_7",
+    "root_fwd_x_7", "root_fwd_y_7",
+    "root_vel_x_7", "root_vel_y_7",
+    "root_speed_7",
+]
+
+
+BINS = 100
+
+# Scale multipliers applied to *candidate* features whose label contains "pos" or "vel".
+# Set to 1.0 to disable. Useful for unit conversion (e.g. normalised → metres).
+CANDIDATE_POS_MULTIPLIER = 1.0
+CANDIDATE_VEL_MULTIPLIER = 1.0
+
+# ──────────────────────────────────────────────────────────────────────────────
+
+
+def _candidate_multiplier(label: str) -> float:
+    """Return CANDIDATE_POS_MULTIPLIER or CANDIDATE_VEL_MULTIPLIER if the label contains 'pos' or 'vel'."""
+    ll = label.lower()
+    if "pos" in ll:
+        return CANDIDATE_POS_MULTIPLIER
+    if "vel" in ll:
+        return CANDIDATE_VEL_MULTIPLIER
+    return 1.0
+
+
+def _read_shape(directory: Path, prefix: str) -> Tuple[int, int]:
+    text = (directory / f"{prefix}Shape.txt").read_text(encoding="utf-8")
+    lines = text.strip().splitlines()
+    return int(lines[0]), int(lines[1])
+
+
+def _read_labels(directory: Path, prefix: str) -> List[str]:
+    labels: List[str] = []
+    with open(directory / f"{prefix}Labels.txt", "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            label = line.split("]", 1)[1].strip() if line.startswith("[") else line
+            labels.append(label)
+    return labels
+
+
+def _read_binary(path: Path, num_samples: int, num_features: int) -> np.ndarray:
+    expected_bytes = num_samples * num_features * 4
+    raw = path.read_bytes()
+    if len(raw) < expected_bytes:
+        raise EOFError(
+            f"{path.name} too small: expected {expected_bytes} bytes "
+            f"({num_samples}×{num_features}×4), got {len(raw)}"
+        )
+    return np.frombuffer(raw[:expected_bytes], dtype=np.float32).reshape(
+        num_samples, num_features
+    )
+
+
+def load_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, List[str]]:
+    """Load Input.bin or Output.bin depending on data_type ('input'|'output')."""
+    d = Path(directory)
+    prefix = "Input" if data_type == "input" else "Output"
+    num_samples, num_features = _read_shape(d, prefix)
+    print(f"  [{data_type}] Shape: {num_samples} samples × {num_features} features")
+    data = _read_binary(d / f"{prefix}.bin", num_samples, num_features)
+    labels = _read_labels(d, prefix)
+    if len(labels) != num_features:
+        print(
+            f"  WARNING: {prefix}Labels.txt has {len(labels)} entries "
+            f"but {prefix}Shape.txt says {num_features} features"
+        )
+    return data, labels
+
+
+def plot_distributions(
+    data: np.ndarray,
+    labels: List[str],
+    label_filter: Optional[List[str]],
+    bins: int,
+) -> None:
+    if label_filter:
+        missing = [l for l in label_filter if l not in labels]
+        if missing:
+            print(f"WARNING: labels not found in dataset: {missing}")
+        indices = [(i, lbl) for i, lbl in enumerate(labels) if lbl in label_filter]
+    else:
+        indices = list(enumerate(labels))
+
+    print(f"Plotting {len(indices)} feature(s)...")
+
+    def _fill_ax(ax: plt.Axes, col_idx: int, label: str) -> None:
+        values = data[:, col_idx]
+        ax.hist(values, bins=bins, color="steelblue", edgecolor="none", alpha=0.85)
+        ax.set_title(f"[{col_idx}] {label}", fontsize=9)
+        stats = (
+            f"min={values.min():.4g}  max={values.max():.4g}  "
+            f"median={np.median(values):.4g}  std={values.std():.4g}"
+        )
+        ax.set_xlabel(stats, fontsize=8)
+        ax.set_ylabel("Count", fontsize=8)
+        ax.grid(True, alpha=0.25)
+
+    if len(indices) <= 12:
+        COLS = 4
+        ROWS = 3
+        fig, axes = plt.subplots(ROWS, COLS, figsize=(16, 9))
+        axes_flat = axes.flatten()
+        for plot_i, (col_idx, label) in enumerate(indices):
+            _fill_ax(axes_flat[plot_i], col_idx, label)
+        # hide unused subplots
+        for ax in axes_flat[len(indices):]:
+            ax.set_visible(False)
+        plt.tight_layout()
+        plt.show()
+    else:
+        for col_idx, label in indices:
+            _, ax = plt.subplots(figsize=(8, 4))
+            _fill_ax(ax, col_idx, label)
+            plt.tight_layout()
+            plt.show()
+
+
+def plot_compare_distributions(
+    b_data: np.ndarray,
+    b_labels: List[str],
+    c_data: np.ndarray,
+    c_labels: List[str],
+    label_filter: Optional[List[str]],
+    bins: int,
+) -> None:
+    """Overlay baseline + candidate histograms on the same subplots.
+
+    Labels must exist in both datasets. If label_filter is None, all shared
+    labels are plotted.
+    """
+    b_label_idx = {lbl: i for i, lbl in enumerate(b_labels)}
+    c_label_idx = {lbl: i for i, lbl in enumerate(c_labels)}
+    shared = [lbl for lbl in b_labels if lbl in c_label_idx]
+
+    if label_filter:
+        missing = [lbl for lbl in label_filter if lbl not in b_label_idx or lbl not in c_label_idx]
+        if missing:
+            print(f"WARNING: labels not in both datasets: {missing}")
+        plot_labels = [lbl for lbl in label_filter if lbl in b_label_idx and lbl in c_label_idx]
+    else:
+        plot_labels = shared
+
+    if not plot_labels:
+        print("ERROR: no shared labels to plot.")
+        return
+
+    print(f"Plotting {len(plot_labels)} feature(s)...")
+
+    COLS = min(4, len(plot_labels))
+    ROWS = (len(plot_labels) + COLS - 1) // COLS
+    fig, axes = plt.subplots(ROWS, COLS, figsize=(5 * COLS, 4 * ROWS), squeeze=False)
+    axes_flat = axes.flatten()
+
+    for plot_i, lbl in enumerate(plot_labels):
+        ax = axes_flat[plot_i]
+        m = _candidate_multiplier(lbl)
+        b_vals = b_data[:, b_label_idx[lbl]]
+        c_vals = c_data[:, c_label_idx[lbl]] * m
+
+        lo = min(b_vals.min(), c_vals.min())
+        hi = max(b_vals.max(), c_vals.max())
+        bin_edges = np.linspace(lo, hi, bins + 1)
+
+        ax.hist(b_vals, bins=bin_edges, color="tab:blue",   edgecolor="none", alpha=0.55, label="baseline")
+        ax.hist(c_vals, bins=bin_edges, color="tab:orange", edgecolor="none", alpha=0.55, label="candidate")
+
+        suffix = f"  (cand ×{m:g})" if m != 1.0 else ""
+        ax.set_title(f"{lbl}{suffix}", fontsize=9)
+        stats = (
+            f"B: [{b_vals.min():.3g}, {b_vals.max():.3g}] μ={b_vals.mean():.3g}\n"
+            f"C: [{c_vals.min():.3g}, {c_vals.max():.3g}] μ={c_vals.mean():.3g}"
+        )
+        ax.set_xlabel(stats, fontsize=7)
+        ax.set_ylabel("Count", fontsize=8)
+        ax.legend(fontsize=7)
+        ax.grid(True, alpha=0.25)
+
+    for ax in axes_flat[len(plot_labels):]:
+        ax.set_visible(False)
+
+    fig.suptitle("Distribution Comparison: Baseline vs Candidate", fontsize=12)
+    plt.tight_layout()
+    plt.show()
+
+
+if __name__ == "__main__":
+    if COMPARE_MODE:
+        print(f"Loading baseline  ({COMPARE_DATA_TYPE}): {BASELINE_DIR}")
+        b_data, b_labels = load_dataset(BASELINE_DIR, COMPARE_DATA_TYPE)
+        print(f"Loading candidate ({COMPARE_DATA_TYPE}): {CANDIDATE_DIR}")
+        c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
+        plot_compare_distributions(b_data, b_labels, c_data, c_labels, LABEL_FILTER, BINS)
+    else:
+        if DATA_TYPE not in ("input", "output"):
+            raise ValueError(f"DATA_TYPE must be 'input' or 'output', got '{DATA_TYPE}'")
+        print(f"Loading ({DATA_TYPE}): {DATA_DIR}")
+        data, labels = load_dataset(DATA_DIR, DATA_TYPE)
+        plot_distributions(data, labels, LABEL_FILTER, BINS)

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -25,6 +25,13 @@ import numpy as np
 
 # ── Config ────────────────────────────────────────────────────────────────────
 
+# Phase-aware modes — set one True to replace histogram plots with phase plots.
+# Combine with COMPARE_MODE=True to overlay baseline vs candidate.
+#   INPUT_PHASE_MODE  expects Input.bin  with 130 features (13 keys × 5 ch × 2)
+#   OUTPUT_PHASE_MODE expects Output.bin with 140 features ( 7 keys × 5 ch × 4)
+INPUT_PHASE_MODE  = False
+OUTPUT_PHASE_MODE = True
+
 # COMPARE_MODE: when True, overlay baseline + candidate histograms on the same plots.
 # When False, plot a single dataset as before.
 COMPARE_MODE = True
@@ -34,22 +41,23 @@ DATA_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
 DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
-BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"
-CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\Inference Data assim scale"
-# BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
-# CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-straight"
-COMPARE_DATA_TYPE = "input"  # "input" | "output" (applies to both)
+# BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"   # AnimHost parity model data
+# CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\inference-data-phase05"                       # AnimHost parity model inference
+# CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
+BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"          # AnimHost survivor latest data
+CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-straight"     # Animhost survivor inference
+COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)
 
 # Format of the CANDIDATE directory:
 #   "gnn" — preprocessed GNN data (Input/Output.bin + InputShape/Labels.txt)
 #   "raw" — raw AnimHost export   (data_x/data_y.bin + metadata.txt + sequences_mann.txt)
-CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
+CANDIDATE_FORMAT = "gnn"  # "gnn" | "raw"
 
 # If non-empty, only these labels are plotted. In compare mode, only labels
 # present in LABEL_FILTER *and* both datasets are shown.
-# LABEL_FILTER: Optional[List[str]] = [
-#     "delta_x", "delta_y", "delta_angle",
-# ]
+LABEL_FILTER: Optional[List[str]] = [
+    "delta_x", "delta_y", "delta_angle",
+]
 # LABEL_FILTER: Optional[List[str]] = [
 #     "out_root_pos_x_7",  "out_root_pos_y_7",
 #     "out_root_pos_x_8",  "out_root_pos_y_8",
@@ -68,6 +76,7 @@ CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
 #     "PhaseUpdate-1",  "PhaseUpdate-2",  "PhaseUpdate-3",  "PhaseUpdate-4",
 #     "PhaseUpdate-5",  "PhaseUpdate-6",  "PhaseUpdate-7",  "PhaseUpdate-8",
 #     "PhaseUpdate-9",  "PhaseUpdate-10", "PhaseUpdate-11", "PhaseUpdate-12",
+#     "PhaseUpdate-13",  "PhaseUpdate-14", "PhaseUpdate-15",
 # ]
 # LABEL_FILTER: Optional[List[str]] = [
 #     "out_root_speed_7",  "out_root_speed_8",  "out_root_speed_9",
@@ -101,6 +110,9 @@ CANDIDATE_POS_MULTIPLIER = 1.0
 CANDIDATE_VEL_MULTIPLIER = 1.0
 
 # ──────────────────────────────────────────────────────────────────────────────
+
+_N_CHANNELS   = 5
+_MAX_SCATTER  = 20_000   # max points per series for scatter plots
 
 
 def _candidate_multiplier(label: str) -> float:
@@ -177,7 +189,7 @@ def load_raw_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarr
     if len(labels) != num_features:
         print(
             f"  WARNING: metadata.txt has {len(labels)} labels "
-            f"but {num_features} features expected"
+            f"but {num_features} expected"
         )
     return data, labels
 
@@ -197,6 +209,290 @@ def load_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, 
         )
     return data, labels
 
+
+# ── Character dimensions ───────────────────────────────────────────────────────
+
+def log_character_dimensions(
+    data: np.ndarray,
+    labels: List[str],
+    tag: str = "",
+) -> None:
+    """Print median bounding-box extent (X/Y/Z) across all frames.
+
+    Finds all jpos_x/y/z columns (input: jpos_*; output: out_jpos_*).
+    Per frame: extent = max(joint) - min(joint) per axis.
+    Reports median + p10/p90 across frames, with a unit hint.
+    """
+    label_idx = {lbl: i for i, lbl in enumerate(labels)}
+
+    axes = {"x": [], "y": [], "z": []}
+    for axis in axes:
+        axes[axis] = [i for lbl, i in label_idx.items() if f"jpos_{axis}_" in lbl]
+
+    if not any(axes.values()):
+        return  # no jpos features in this dataset
+
+    n_joints = len(axes["x"])
+    result = {}
+    for axis, cols in axes.items():
+        if not cols:
+            result[axis] = (float("nan"),) * 3
+            continue
+        vals = data[:, cols]                              # (N, J)
+        extent = vals.max(axis=1) - vals.min(axis=1)     # (N,)
+        result[axis] = (
+            float(np.median(extent)),
+            float(np.percentile(extent, 10)),
+            float(np.percentile(extent, 90)),
+        )
+
+    unit_hint = " (~cm)" if result["y"][0] > 10 else " (~m)"
+    prefix = f" [{tag}]" if tag else ""
+    print(
+        f"\n── Character dimensions{prefix} "
+        f"(median bbox, N={data.shape[0]} frames, {n_joints} joints){unit_hint} ──"
+    )
+    for name, axis in [("X (lateral) ", "x"), ("Y (vertical)", "y"), ("Z (depth)   ", "z")]:
+        med, p10, p90 = result[axis]
+        print(f"  {name}: {med:6.2f}   [p10={p10:.2f}  p90={p90:.2f}]")
+    print()
+
+
+# ── Phase decode ───────────────────────────────────────────────────────────────
+
+def decode_input_phase(data: np.ndarray) -> np.ndarray:
+    """(N, 130) → (N, 13, 5, 2)   last dim = [x, y]
+
+    Layout: key*10 + channel*2 + {0=x, 1=y}
+    Amplitude is baked into the vector radius.
+    """
+    return data.reshape(data.shape[0], 13, _N_CHANNELS, 2)
+
+
+def decode_output_phase(data: np.ndarray) -> np.ndarray:
+    """(N, 140) → (N, 7, 5, 4)   last dim = [x, y, amp, freq]
+
+    Per-key block of 20: [ch0_x ch0_y … ch4_y (10)] | [ch0…ch4 amp (5)] | [ch0…ch4 freq (5)]
+    """
+    N = data.shape[0]
+    blocks   = data.reshape(N, 7, 20)
+    phase2d  = blocks[:, :, :10].reshape(N, 7, _N_CHANNELS, 2)   # (N,7,5,2)
+    amp      = blocks[:, :, 10:15][..., np.newaxis]               # (N,7,5,1)
+    freq     = blocks[:, :, 15:20][..., np.newaxis]               # (N,7,5,1)
+    return np.concatenate([phase2d, amp, freq], axis=-1)          # (N,7,5,4)
+
+
+# ── Phase plot helpers ─────────────────────────────────────────────────────────
+
+def _flat_ch(arr: np.ndarray, ch: int) -> np.ndarray:
+    """Flatten (N, K, 5[, ...]) → 1-D array for channel ch."""
+    return arr[:, :, ch].ravel()
+
+
+def _subsample_xy(x: np.ndarray, y: np.ndarray) -> Tuple[np.ndarray, np.ndarray]:
+    if len(x) > _MAX_SCATTER:
+        idx = np.random.default_rng(42).choice(len(x), _MAX_SCATTER, replace=False)
+        return x[idx], y[idx]
+    return x, y
+
+
+# ── Phase plots ────────────────────────────────────────────────────────────────
+
+def plot_phase_scatter(
+    b_xy: np.ndarray,
+    c_xy: np.ndarray,
+    title: str,
+    compare: bool,
+) -> None:
+    """2D scatter / density per channel.
+
+    b_xy, c_xy: (N, K, 5, 2)
+    Single mode: hexbin density map.
+    Compare mode: two subsampled scatter series (baseline blue, candidate orange).
+    """
+    fig, axes = plt.subplots(1, _N_CHANNELS, figsize=(20, 4))
+    fig.suptitle(title)
+
+    for ch, ax in enumerate(axes):
+        bx = b_xy[:, :, ch, 0].ravel()
+        by = b_xy[:, :, ch, 1].ravel()
+
+        if compare:
+            cx = c_xy[:, :, ch, 0].ravel()
+            cy = c_xy[:, :, ch, 1].ravel()
+            bx2, by2 = _subsample_xy(bx, by)
+            cx2, cy2 = _subsample_xy(cx, cy)
+            ax.scatter(bx2, by2, s=1, alpha=0.2, color="tab:blue",   label="baseline",  rasterized=True)
+            ax.scatter(cx2, cy2, s=1, alpha=0.2, color="tab:orange", label="candidate", rasterized=True)
+            if ch == 0:
+                ax.legend(fontsize=7, markerscale=5)
+        else:
+            ax.hexbin(bx, by, gridsize=60, cmap="Blues", mincnt=1)
+
+        ax.set_aspect("equal")
+        ax.axhline(0, color="k", lw=0.4, alpha=0.4)
+        ax.axvline(0, color="k", lw=0.4, alpha=0.4)
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("x", fontsize=8)
+        ax.set_ylabel("y", fontsize=8)
+        ax.grid(True, alpha=0.2)
+
+    plt.tight_layout()
+
+
+def plot_phase_polar(
+    b_xy: np.ndarray,
+    c_xy: np.ndarray,
+    title: str,
+    compare: bool,
+) -> None:
+    """Rose (polar histogram) of phase angle per channel.
+
+    b_xy, c_xy: (N, K, 5, 2)
+    """
+    N_BINS  = 36
+    edges   = np.linspace(0, 2 * np.pi, N_BINS + 1)
+    width   = 2 * np.pi / N_BINS
+    centers = (edges[:-1] + edges[1:]) / 2
+
+    fig, axes = plt.subplots(1, _N_CHANNELS, figsize=(20, 4),
+                             subplot_kw={"projection": "polar"})
+    fig.suptitle(title)
+
+    for ch, ax in enumerate(axes):
+        bx = b_xy[:, :, ch, 0].ravel()
+        by = b_xy[:, :, ch, 1].ravel()
+        b_theta  = np.arctan2(by, bx) % (2 * np.pi)
+        b_counts, _ = np.histogram(b_theta, bins=edges)
+        b_counts = b_counts / b_counts.max()
+
+        if compare:
+            cx = c_xy[:, :, ch, 0].ravel()
+            cy = c_xy[:, :, ch, 1].ravel()
+            c_theta  = np.arctan2(cy, cx) % (2 * np.pi)
+            c_counts, _ = np.histogram(c_theta, bins=edges)
+            c_counts = c_counts / c_counts.max()
+            ax.bar(centers,                b_counts, width=width * 0.45, color="tab:blue",   alpha=0.65, align="center", label="baseline")
+            ax.bar(centers + width * 0.45, c_counts, width=width * 0.45, color="tab:orange", alpha=0.65, align="center", label="candidate")
+        else:
+            ax.bar(centers, b_counts, width=width, color="tab:blue", alpha=0.8, align="center")
+
+        ax.set_title(f"Ch {ch + 1}", fontsize=9, pad=10)
+        ax.set_yticks([])
+
+    plt.tight_layout()
+
+
+def plot_phase_amplitude(
+    b_r: np.ndarray,
+    c_r: np.ndarray,
+    title: str,
+    compare: bool,
+) -> None:
+    """Amplitude histogram per channel.
+
+    b_r, c_r: (N, K, 5)  — pre-computed radii or explicit amp field.
+    """
+    fig, axes = plt.subplots(1, _N_CHANNELS, figsize=(20, 4))
+    fig.suptitle(title)
+
+    for ch, ax in enumerate(axes):
+        br = _flat_ch(b_r, ch)
+        if compare:
+            cr = _flat_ch(c_r, ch)
+            lo = min(br.min(), cr.min())
+            hi = max(br.max(), cr.max())
+            bins = np.linspace(lo, hi, BINS + 1)
+            ax.hist(br, bins=bins, color="tab:blue",   alpha=0.55, density=True, label="baseline")
+            ax.hist(cr, bins=bins, color="tab:orange", alpha=0.55, density=True, label="candidate")
+            if ch == 0:
+                ax.legend(fontsize=7)
+        else:
+            ax.hist(br, bins=BINS, color="steelblue", alpha=0.85)
+
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("amplitude", fontsize=8)
+        ax.set_ylabel("density" if compare else "count", fontsize=8)
+        ax.grid(True, alpha=0.25)
+
+    plt.tight_layout()
+
+
+def plot_phase_temporal(
+    b_ph: np.ndarray,
+    c_ph: np.ndarray,
+    title: str,
+    compare: bool,
+) -> None:
+    """Heatmap of mean amplitude over (keys × channels). Input phase only.
+
+    b_ph, c_ph: (N, 13, 5, 2)
+    """
+    b_r = np.sqrt((b_ph ** 2).sum(-1)).mean(0)   # (13, 5)
+
+    if compare:
+        c_r   = np.sqrt((c_ph ** 2).sum(-1)).mean(0)
+        vmin  = min(b_r.min(), c_r.min())
+        vmax  = max(b_r.max(), c_r.max())
+        fig, (ax_b, ax_c) = plt.subplots(1, 2, figsize=(14, 4))
+        fig.suptitle(title)
+        for ax, mat, lbl in [(ax_b, b_r, "baseline"), (ax_c, c_r, "candidate")]:
+            im = ax.imshow(mat.T, aspect="auto", origin="lower", vmin=vmin, vmax=vmax, cmap="viridis")
+            ax.set_title(lbl, fontsize=9)
+            ax.set_xlabel("key offset  (0 = far past … 12 = far future)", fontsize=8)
+            ax.set_ylabel("channel", fontsize=8)
+            ax.set_yticks(range(_N_CHANNELS))
+            ax.set_yticklabels([f"Ch {c + 1}" for c in range(_N_CHANNELS)], fontsize=8)
+            fig.colorbar(im, ax=ax, label="mean amplitude")
+    else:
+        fig, ax = plt.subplots(figsize=(10, 3))
+        fig.suptitle(title)
+        im = ax.imshow(b_r.T, aspect="auto", origin="lower", cmap="viridis")
+        ax.set_xlabel("key offset  (0 = far past … 12 = far future)", fontsize=8)
+        ax.set_ylabel("channel", fontsize=8)
+        ax.set_yticks(range(_N_CHANNELS))
+        ax.set_yticklabels([f"Ch {c + 1}" for c in range(_N_CHANNELS)], fontsize=8)
+        fig.colorbar(im, ax=ax, label="mean amplitude")
+
+    plt.tight_layout()
+
+
+def plot_phase_frequency(
+    b_freq: np.ndarray,
+    c_freq: np.ndarray,
+    title: str,
+    compare: bool,
+) -> None:
+    """Frequency histogram per channel.
+
+    b_freq, c_freq: (N, K, 5)
+    """
+    fig, axes = plt.subplots(1, _N_CHANNELS, figsize=(20, 4))
+    fig.suptitle(title)
+
+    for ch, ax in enumerate(axes):
+        bf = _flat_ch(b_freq, ch)
+        if compare:
+            cf = _flat_ch(c_freq, ch)
+            lo = min(bf.min(), cf.min())
+            hi = max(bf.max(), cf.max())
+            bins = np.linspace(lo, hi, BINS + 1)
+            ax.hist(bf, bins=bins, color="tab:blue",   alpha=0.55, density=True, label="baseline")
+            ax.hist(cf, bins=bins, color="tab:orange", alpha=0.55, density=True, label="candidate")
+            if ch == 0:
+                ax.legend(fontsize=7)
+        else:
+            ax.hist(bf, bins=BINS, color="steelblue", alpha=0.85)
+
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("frequency", fontsize=8)
+        ax.set_ylabel("density" if compare else "count", fontsize=8)
+        ax.grid(True, alpha=0.25)
+
+    plt.tight_layout()
+
+
+# ── Histogram plots ────────────────────────────────────────────────────────────
 
 def plot_distributions(
     data: np.ndarray,
@@ -315,18 +611,75 @@ def plot_compare_distributions(
 
 
 if __name__ == "__main__":
-    if COMPARE_MODE:
+    if INPUT_PHASE_MODE or OUTPUT_PHASE_MODE:
+        dtype  = "input" if INPUT_PHASE_MODE else "output"
+        decode = decode_input_phase if INPUT_PHASE_MODE else decode_output_phase
+        mode   = "Input Phase" if INPUT_PHASE_MODE else "Output Phase"
+
+        label_prefix = "PhaseSpace-" if INPUT_PHASE_MODE else "PhaseUpdate-"
+
+        def _extract_phase(data: np.ndarray, labels: List[str]) -> np.ndarray:
+            indices = [i for i, lbl in enumerate(labels) if lbl.startswith(label_prefix)]
+            if not indices:
+                raise ValueError(f"No labels starting with '{label_prefix}' found in dataset.")
+            print(f"  Extracted {len(indices)} phase columns ({label_prefix}*)")
+            return data[:, indices]
+
+        if COMPARE_MODE:
+            print(f"Loading baseline  ({dtype}): {BASELINE_DIR}")
+            b_data, b_labels = load_dataset(BASELINE_DIR, dtype)
+            log_character_dimensions(b_data, b_labels, "baseline")
+            print(f"Loading candidate ({dtype}): {CANDIDATE_DIR}")
+            c_data, c_labels = load_dataset(CANDIDATE_DIR, dtype)
+            log_character_dimensions(c_data, c_labels, "candidate")
+            b_ph = decode(_extract_phase(b_data, b_labels))
+            c_ph = decode(_extract_phase(c_data, c_labels))
+            suffix = "Baseline vs Candidate"
+        else:
+            print(f"Loading ({dtype}): {DATA_DIR}")
+            data, labels = load_dataset(DATA_DIR, dtype)
+            log_character_dimensions(data, labels)
+            b_ph = c_ph = decode(_extract_phase(data, labels))
+            suffix = DATA_DIR
+
+        compare = COMPARE_MODE
+
+        if INPUT_PHASE_MODE:
+            b_r = np.sqrt((b_ph ** 2).sum(-1))   # (N, 13, 5)
+            c_r = np.sqrt((c_ph ** 2).sum(-1))
+            plot_phase_scatter(b_ph, c_ph,   f"{mode} Scatter — {suffix}", compare)
+            plot_phase_polar(b_ph, c_ph,     f"{mode} Angle Distribution — {suffix}", compare)
+            plot_phase_amplitude(b_r, c_r,   f"{mode} Amplitude — {suffix}", compare)
+            plot_phase_temporal(b_ph, c_ph,  f"{mode} Temporal Amplitude — {suffix}", compare)
+        else:
+            b_xy   = b_ph[..., :2]          # (N, 7, 5, 2)
+            c_xy   = c_ph[..., :2]
+            b_amp  = b_ph[..., 2]           # (N, 7, 5)
+            c_amp  = c_ph[..., 2]
+            b_freq = b_ph[..., 3]           # (N, 7, 5)
+            c_freq = c_ph[..., 3]
+            plot_phase_scatter(b_xy, c_xy,     f"{mode} Scatter — {suffix}", compare)
+            plot_phase_polar(b_xy, c_xy,       f"{mode} Angle Distribution — {suffix}", compare)
+            plot_phase_amplitude(b_amp, c_amp, f"{mode} Amplitude — {suffix}", compare)
+            plot_phase_frequency(b_freq, c_freq, f"{mode} Frequency — {suffix}", compare)
+
+        plt.show()
+
+    elif COMPARE_MODE:
         print(f"Loading baseline  ({COMPARE_DATA_TYPE}): {BASELINE_DIR}")
         b_data, b_labels = load_dataset(BASELINE_DIR, COMPARE_DATA_TYPE)
+        log_character_dimensions(b_data, b_labels, "baseline")
         print(f"Loading candidate ({COMPARE_DATA_TYPE}) [{CANDIDATE_FORMAT}]: {CANDIDATE_DIR}")
         if CANDIDATE_FORMAT == "raw":
             c_data, c_labels = load_raw_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
         else:
             c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
+        log_character_dimensions(c_data, c_labels, "candidate")
         plot_compare_distributions(b_data, b_labels, c_data, c_labels, LABEL_FILTER, BINS)
     else:
         if DATA_TYPE not in ("input", "output"):
             raise ValueError(f"DATA_TYPE must be 'input' or 'output', got '{DATA_TYPE}'")
         print(f"Loading ({DATA_TYPE}): {DATA_DIR}")
         data, labels = load_dataset(DATA_DIR, DATA_TYPE)
+        log_character_dimensions(data, labels)
         plot_distributions(data, labels, LABEL_FILTER, BINS)

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -34,9 +34,11 @@ DATA_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
 DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
-BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
-CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-curve"
-COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)
+BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"
+CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\Inference Data assim scale"
+# BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
+# CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-straight"
+COMPARE_DATA_TYPE = "input"  # "input" | "output" (applies to both)
 
 # Format of the CANDIDATE directory:
 #   "gnn" — preprocessed GNN data (Input/Output.bin + InputShape/Labels.txt)
@@ -48,24 +50,28 @@ CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
 # LABEL_FILTER: Optional[List[str]] = [
 #     "delta_x", "delta_y", "delta_angle",
 # ]
-LABEL_FILTER: Optional[List[str]] = [
-    "out_root_pos_x_7",  "out_root_pos_y_7",
-    "out_root_pos_x_8",  "out_root_pos_y_8",
-    "out_root_pos_x_9",  "out_root_pos_y_9",
-    "out_root_pos_x_10", "out_root_pos_y_10",
-    "out_root_pos_x_11", "out_root_pos_y_11",
-    "out_root_pos_x_12", "out_root_pos_y_12",
-]
 # LABEL_FILTER: Optional[List[str]] = [
-#     "out_jpos_x_hip", "out_jpos_y_hip", "out_jpos_z_hip",
-#     "out_jrot_0_hip", "out_jrot_1_hip", "out_jrot_2_hip",
-#     "out_jrot_3_hip", "out_jrot_4_hip", "out_jrot_5_hip",
-#     "out_jvel_x_hip", "out_jvel_y_hip", "out_jvel_z_hip",
+#     "out_root_pos_x_7",  "out_root_pos_y_7",
+#     "out_root_pos_x_8",  "out_root_pos_y_8",
+#     "out_root_pos_x_9",  "out_root_pos_y_9",
+#     "out_root_pos_x_10", "out_root_pos_y_10",
+#     "out_root_pos_x_11", "out_root_pos_y_11",
+#     "out_root_pos_x_12", "out_root_pos_y_12",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "out_jpos_x_Hips", "out_jpos_y_Hips", "out_jpos_z_Hips",
+#     "out_jrot_0_Hips", "out_jrot_1_Hips", "out_jrot_2_Hips",
+#     "out_jrot_3_Hips", "out_jrot_4_Hips", "out_jrot_5_Hips",
+#     "out_jvel_x_Hips", "out_jvel_y_Hips", "out_jvel_z_Hips",
 # ]
 # LABEL_FILTER: Optional[List[str]] = [
 #     "PhaseUpdate-1",  "PhaseUpdate-2",  "PhaseUpdate-3",  "PhaseUpdate-4",
 #     "PhaseUpdate-5",  "PhaseUpdate-6",  "PhaseUpdate-7",  "PhaseUpdate-8",
 #     "PhaseUpdate-9",  "PhaseUpdate-10", "PhaseUpdate-11", "PhaseUpdate-12",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "out_root_speed_7",  "out_root_speed_8",  "out_root_speed_9",
+#     "out_root_speed_10", "out_root_speed_11", "out_root_speed_12",
 # ]
 
 # LABEL_FILTER: Optional[List[str]] = [
@@ -74,7 +80,18 @@ LABEL_FILTER: Optional[List[str]] = [
 #     "root_vel_x_7", "root_vel_y_7",
 #     "root_speed_7",
 # ]
-
+# LABEL_FILTER: Optional[List[str]] = [
+#     "root_speed_0",  "root_speed_1",  "root_speed_2",  "root_speed_3",
+#     "root_speed_4",  "root_speed_5",  "root_speed_6",  "root_speed_7",
+#     "root_speed_8",  "root_speed_9",  "root_speed_10", "root_speed_11",
+#     "root_speed_12",
+# ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "jpos_x_Hips", "jpos_y_Hips", "jpos_z_Hips",
+#     "jrot_0_Hips", "jrot_1_Hips", "jrot_2_Hips",
+#     "jrot_3_Hips", "jrot_4_Hips", "jrot_5_Hips",
+#     "jvel_x_Hips", "jvel_y_Hips", "jvel_z_Hips",
+# ]
 
 BINS = 100
 

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -30,7 +30,7 @@ import numpy as np
 #   INPUT_PHASE_MODE  expects Input.bin  with 130 features (13 keys × 5 ch × 2)
 #   OUTPUT_PHASE_MODE expects Output.bin with 140 features ( 7 keys × 5 ch × 4)
 INPUT_PHASE_MODE  = False
-OUTPUT_PHASE_MODE = False
+OUTPUT_PHASE_MODE = True
 
 # COMPARE_MODE: when True, overlay baseline + candidate histograms on the same plots.
 # When False, plot a single dataset as before.
@@ -42,16 +42,17 @@ DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
 BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"   # AnimHost parity model data
-CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"                       # AnimHost parity model inference
-# CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
+# CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"                       # AnimHost parity model inference
+CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
 # BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"          # AnimHost survivor latest data
 # CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\infernece-data-7x1m"     # Animhost survivor inference
 COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)
 
-# Format of the CANDIDATE directory:
-#   "gnn" — preprocessed GNN data (Input/Output.bin + InputShape/Labels.txt)
-#   "raw" — raw AnimHost export   (data_x/data_y.bin + metadata.txt + sequences_mann.txt)
-CANDIDATE_FORMAT = "gnn"  # "gnn" | "raw"
+# Source pipeline — controls output-phase vector stacking order.
+#   "animhost" — grouped: [all phase2D | all amp | all freq] per key
+#   "unity"    — interleaved: (x, y, amp, freq) per channel per key
+BASELINE_SOURCE  = "animhost"  # "animhost" | "unity"
+CANDIDATE_SOURCE = "unity"  # "animhost" | "unity"
 
 # If non-empty, only these labels are plotted. In compare mode, only labels
 # present in LABEL_FILTER *and* both datasets are shown.
@@ -105,10 +106,10 @@ CANDIDATE_FORMAT = "gnn"  # "gnn" | "raw"
 #     "jpos_z_Spine1", "jpos_z_Tail", "jpos_z_Neck", "jpos_z_Head",
 #     "root_speed_0", "jpos_z_RightShoulder", "root_speed_1", "jpos_z_LeftShoulder",
 # ]
-LABEL_FILTER: Optional[List[str]] = [
-    "out_root_fwd_y_8", "out_root_fwd_y_9", "out_root_fwd_y_10",
-    "out_root_fwd_y_7", "out_root_fwd_y_11", "out_root_fwd_y_12",
-]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "out_root_fwd_y_8", "out_root_fwd_y_9", "out_root_fwd_y_10",
+#     "out_root_fwd_y_7", "out_root_fwd_y_11", "out_root_fwd_y_12",
+# ]
 
 
 
@@ -164,44 +165,6 @@ def _read_binary(path: Path, num_samples: int, num_features: int) -> np.ndarray:
     return np.frombuffer(raw[:expected_bytes], dtype=np.float32).reshape(
         num_samples, num_features
     )
-
-
-def _count_lines(path: Path) -> int:
-    """Return the number of non-empty lines in a text file."""
-    with open(path, "r", encoding="utf-8") as f:
-        return sum(1 for line in f if line.strip())
-
-
-def load_raw_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, List[str]]:
-    """Load data_x.bin or data_y.bin with labels from metadata.txt.
-
-    metadata.txt format (comma-separated):
-      row 0: num_input_features, label_0, label_1, ...
-      row 1: num_output_features, label_0, label_1, ...
-
-    Sample count is derived from sequences_mann.txt (one non-empty line per sample).
-    """
-    d = Path(directory)
-    with open(d / "metadata.txt", "r", encoding="utf-8") as f:
-        lines = [l.strip() for l in f if l.strip()]
-
-    row_idx = 0 if data_type == "input" else 1
-    parts = lines[row_idx].split(",")
-    num_features = int(parts[0])
-    labels = [p.strip() for p in parts[1 : num_features + 1]]
-
-    num_samples = _count_lines(d / "sequences_mann.txt")
-    print(f"  [{data_type}] Shape: {num_samples} samples × {num_features} features")
-
-    bin_name = "data_x.bin" if data_type == "input" else "data_y.bin"
-    data = _read_binary(d / bin_name, num_samples, num_features)
-
-    if len(labels) != num_features:
-        print(
-            f"  WARNING: metadata.txt has {len(labels)} labels "
-            f"but {num_features} expected"
-        )
-    return data, labels
 
 
 def load_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, List[str]]:
@@ -270,26 +233,33 @@ def log_character_dimensions(
 
 # ── Phase decode ───────────────────────────────────────────────────────────────
 
-def decode_input_phase(data: np.ndarray) -> np.ndarray:
+def decode_input_phase(data: np.ndarray, source: str = "animhost") -> np.ndarray:
     """(N, 130) → (N, 13, 5, 2)   last dim = [x, y]
 
     Layout: key*10 + channel*2 + {0=x, 1=y}
     Amplitude is baked into the vector radius.
+    Input phase layout is identical for both Unity and AnimHost.
     """
     return data.reshape(data.shape[0], 13, _N_CHANNELS, 2)
 
 
-def decode_output_phase(data: np.ndarray) -> np.ndarray:
+def decode_output_phase(data: np.ndarray, source: str = "animhost") -> np.ndarray:
     """(N, 140) → (N, 7, 5, 4)   last dim = [x, y, amp, freq]
 
-    Per-key block of 20: [ch0_x ch0_y … ch4_y (10)] | [ch0…ch4 amp (5)] | [ch0…ch4 freq (5)]
+    AnimHost layout (grouped per key):
+        [ch0_x ch0_y … ch4_y (10)] | [ch0…ch4 amp (5)] | [ch0…ch4 freq (5)]
+    Unity layout (interleaved per channel):
+        [ch0_x ch0_y ch0_amp ch0_freq, ch1_x ch1_y ch1_amp ch1_freq, …]
     """
     N = data.shape[0]
-    blocks   = data.reshape(N, 7, 20)
-    phase2d  = blocks[:, :, :10].reshape(N, 7, _N_CHANNELS, 2)   # (N,7,5,2)
-    amp      = blocks[:, :, 10:15][..., np.newaxis]               # (N,7,5,1)
-    freq     = blocks[:, :, 15:20][..., np.newaxis]               # (N,7,5,1)
-    return np.concatenate([phase2d, amp, freq], axis=-1)          # (N,7,5,4)
+    if source == "unity":
+        return data.reshape(N, 7, _N_CHANNELS, 4)                    # (N,7,5,4)
+    else:  # animhost
+        blocks   = data.reshape(N, 7, 20)
+        phase2d  = blocks[:, :, :10].reshape(N, 7, _N_CHANNELS, 2)   # (N,7,5,2)
+        amp      = blocks[:, :, 10:15][..., np.newaxis]               # (N,7,5,1)
+        freq     = blocks[:, :, 15:20][..., np.newaxis]               # (N,7,5,1)
+        return np.concatenate([phase2d, amp, freq], axis=-1)          # (N,7,5,4)
 
 
 # ── Phase plot helpers ─────────────────────────────────────────────────────────
@@ -636,20 +606,20 @@ if __name__ == "__main__":
             return data[:, indices]
 
         if COMPARE_MODE:
-            print(f"Loading baseline  ({dtype}): {BASELINE_DIR}")
+            print(f"Loading baseline  ({dtype}) [{BASELINE_SOURCE}]: {BASELINE_DIR}")
             b_data, b_labels = load_dataset(BASELINE_DIR, dtype)
             log_character_dimensions(b_data, b_labels, "baseline")
-            print(f"Loading candidate ({dtype}): {CANDIDATE_DIR}")
+            print(f"Loading candidate ({dtype}) [{CANDIDATE_SOURCE}]: {CANDIDATE_DIR}")
             c_data, c_labels = load_dataset(CANDIDATE_DIR, dtype)
             log_character_dimensions(c_data, c_labels, "candidate")
-            b_ph = decode(_extract_phase(b_data, b_labels))
-            c_ph = decode(_extract_phase(c_data, c_labels))
+            b_ph = decode(_extract_phase(b_data, b_labels), BASELINE_SOURCE)
+            c_ph = decode(_extract_phase(c_data, c_labels), CANDIDATE_SOURCE)
             suffix = "Baseline vs Candidate"
         else:
             print(f"Loading ({dtype}): {DATA_DIR}")
             data, labels = load_dataset(DATA_DIR, dtype)
             log_character_dimensions(data, labels)
-            b_ph = c_ph = decode(_extract_phase(data, labels))
+            b_ph = c_ph = decode(_extract_phase(data, labels), BASELINE_SOURCE)
             suffix = DATA_DIR
 
         compare = COMPARE_MODE
@@ -679,11 +649,8 @@ if __name__ == "__main__":
         print(f"Loading baseline  ({COMPARE_DATA_TYPE}): {BASELINE_DIR}")
         b_data, b_labels = load_dataset(BASELINE_DIR, COMPARE_DATA_TYPE)
         log_character_dimensions(b_data, b_labels, "baseline")
-        print(f"Loading candidate ({COMPARE_DATA_TYPE}) [{CANDIDATE_FORMAT}]: {CANDIDATE_DIR}")
-        if CANDIDATE_FORMAT == "raw":
-            c_data, c_labels = load_raw_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
-        else:
-            c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
+        print(f"Loading candidate ({COMPARE_DATA_TYPE}): {CANDIDATE_DIR}")
+        c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
         log_character_dimensions(c_data, c_labels, "candidate")
         plot_compare_distributions(b_data, b_labels, c_data, c_labels, LABEL_FILTER, BINS)
     else:

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -30,7 +30,7 @@ import numpy as np
 #   INPUT_PHASE_MODE  expects Input.bin  with 130 features (13 keys × 5 ch × 2)
 #   OUTPUT_PHASE_MODE expects Output.bin with 140 features ( 7 keys × 5 ch × 4)
 INPUT_PHASE_MODE  = False
-OUTPUT_PHASE_MODE = True
+OUTPUT_PHASE_MODE = False
 
 # COMPARE_MODE: when True, overlay baseline + candidate histograms on the same plots.
 # When False, plot a single dataset as before.
@@ -42,8 +42,8 @@ DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
 BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"   # AnimHost parity model data
-# CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"                       # AnimHost parity model inference
-CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
+CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"                       # AnimHost parity model inference
+# CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
 # BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"          # AnimHost survivor latest data
 # CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\infernece-data-7x1m"     # Animhost survivor inference
 COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -30,7 +30,7 @@ import numpy as np
 #   INPUT_PHASE_MODE  expects Input.bin  with 130 features (13 keys × 5 ch × 2)
 #   OUTPUT_PHASE_MODE expects Output.bin with 140 features ( 7 keys × 5 ch × 4)
 INPUT_PHASE_MODE  = False
-OUTPUT_PHASE_MODE = True
+OUTPUT_PHASE_MODE = False
 
 # COMPARE_MODE: when True, overlay baseline + candidate histograms on the same plots.
 # When False, plot a single dataset as before.
@@ -41,11 +41,11 @@ DATA_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
 DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
-# BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"   # AnimHost parity model data
-# CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\inference-data-phase05"                       # AnimHost parity model inference
+BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"   # AnimHost parity model data
+CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"                       # AnimHost parity model inference
 # CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"                     # Unity parity model data
-BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"          # AnimHost survivor latest data
-CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-straight"     # Animhost survivor inference
+# BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"          # AnimHost survivor latest data
+# CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\infernece-data-7x1m"     # Animhost survivor inference
 COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)
 
 # Format of the CANDIDATE directory:
@@ -55,9 +55,9 @@ CANDIDATE_FORMAT = "gnn"  # "gnn" | "raw"
 
 # If non-empty, only these labels are plotted. In compare mode, only labels
 # present in LABEL_FILTER *and* both datasets are shown.
-LABEL_FILTER: Optional[List[str]] = [
-    "delta_x", "delta_y", "delta_angle",
-]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "delta_x", "delta_y", "delta_angle",
+# ]
 # LABEL_FILTER: Optional[List[str]] = [
 #     "out_root_pos_x_7",  "out_root_pos_y_7",
 #     "out_root_pos_x_8",  "out_root_pos_y_8",
@@ -101,6 +101,16 @@ LABEL_FILTER: Optional[List[str]] = [
 #     "jrot_3_Hips", "jrot_4_Hips", "jrot_5_Hips",
 #     "jvel_x_Hips", "jvel_y_Hips", "jvel_z_Hips",
 # ]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "jpos_z_Spine1", "jpos_z_Tail", "jpos_z_Neck", "jpos_z_Head",
+#     "root_speed_0", "jpos_z_RightShoulder", "root_speed_1", "jpos_z_LeftShoulder",
+# ]
+LABEL_FILTER: Optional[List[str]] = [
+    "out_root_fwd_y_8", "out_root_fwd_y_9", "out_root_fwd_y_10",
+    "out_root_fwd_y_7", "out_root_fwd_y_11", "out_root_fwd_y_12",
+]
+
+
 
 BINS = 100
 

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -35,8 +35,8 @@ DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
 BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
-CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\nomirror-processed-pr"
-COMPARE_DATA_TYPE = "input"  # "input" | "output" (applies to both)
+CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\inference-data-curve"
+COMPARE_DATA_TYPE = "output"  # "input" | "output" (applies to both)
 
 # Format of the CANDIDATE directory:
 #   "gnn" — preprocessed GNN data (Input/Output.bin + InputShape/Labels.txt)
@@ -48,14 +48,14 @@ CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
 # LABEL_FILTER: Optional[List[str]] = [
 #     "delta_x", "delta_y", "delta_angle",
 # ]
-# LABEL_FILTER: Optional[List[str]] = [
-#     "out_root_pos_x_7",  "out_root_pos_y_7",
-#     "out_root_pos_x_8",  "out_root_pos_y_8",
-#     "out_root_pos_x_9",  "out_root_pos_y_9",
-#     "out_root_pos_x_10", "out_root_pos_y_10",
-#     "out_root_pos_x_11", "out_root_pos_y_11",
-#     "out_root_pos_x_12", "out_root_pos_y_12",
-# ]
+LABEL_FILTER: Optional[List[str]] = [
+    "out_root_pos_x_7",  "out_root_pos_y_7",
+    "out_root_pos_x_8",  "out_root_pos_y_8",
+    "out_root_pos_x_9",  "out_root_pos_y_9",
+    "out_root_pos_x_10", "out_root_pos_y_10",
+    "out_root_pos_x_11", "out_root_pos_y_11",
+    "out_root_pos_x_12", "out_root_pos_y_12",
+]
 # LABEL_FILTER: Optional[List[str]] = [
 #     "out_jpos_x_hip", "out_jpos_y_hip", "out_jpos_z_hip",
 #     "out_jrot_0_hip", "out_jrot_1_hip", "out_jrot_2_hip",
@@ -68,12 +68,12 @@ CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
 #     "PhaseUpdate-9",  "PhaseUpdate-10", "PhaseUpdate-11", "PhaseUpdate-12",
 # ]
 
-LABEL_FILTER: Optional[List[str]] = [
-    "root_pos_x_7", "root_pos_y_7",
-    "root_fwd_x_7", "root_fwd_y_7",
-    "root_vel_x_7", "root_vel_y_7",
-    "root_speed_7",
-]
+# LABEL_FILTER: Optional[List[str]] = [
+#     "root_pos_x_7", "root_pos_y_7",
+#     "root_fwd_x_7", "root_fwd_y_7",
+#     "root_vel_x_7", "root_vel_y_7",
+#     "root_speed_7",
+# ]
 
 
 BINS = 100
@@ -275,8 +275,8 @@ def plot_compare_distributions(
         hi = max(b_vals.max(), c_vals.max())
         bin_edges = np.linspace(lo, hi, bins + 1)
 
-        ax.hist(b_vals, bins=bin_edges, color="tab:blue",   edgecolor="none", alpha=0.55, label="baseline")
-        ax.hist(c_vals, bins=bin_edges, color="tab:orange", edgecolor="none", alpha=0.55, label="candidate")
+        ax.hist(b_vals, bins=bin_edges, color="tab:blue",   edgecolor="none", alpha=0.55, label="baseline",  density=True)
+        ax.hist(c_vals, bins=bin_edges, color="tab:orange", edgecolor="none", alpha=0.55, label="candidate", density=True)
 
         suffix = f"  (cand ×{m:g})" if m != 1.0 else ""
         ax.set_title(f"{lbl}{suffix}", fontsize=9)
@@ -285,7 +285,7 @@ def plot_compare_distributions(
             f"C: [{c_vals.min():.3g}, {c_vals.max():.3g}] μ={c_vals.mean():.3g}"
         )
         ax.set_xlabel(stats, fontsize=7)
-        ax.set_ylabel("Count", fontsize=8)
+        ax.set_ylabel("Density", fontsize=8)
         ax.legend(fontsize=7)
         ax.grid(True, alpha=0.25)
 

--- a/python/scripts/gnn_data_distribution.py
+++ b/python/scripts/gnn_data_distribution.py
@@ -35,8 +35,13 @@ DATA_TYPE = "output"  # "input" | "output"
 
 # Compare-mode config (used when COMPARE_MODE = True)
 BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\candidate\GNN Data"
-CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"
+CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\survivor-1\nomirror-processed-pr"
 COMPARE_DATA_TYPE = "input"  # "input" | "output" (applies to both)
+
+# Format of the CANDIDATE directory:
+#   "gnn" — preprocessed GNN data (Input/Output.bin + InputShape/Labels.txt)
+#   "raw" — raw AnimHost export   (data_x/data_y.bin + metadata.txt + sequences_mann.txt)
+CANDIDATE_FORMAT = "raw"  # "gnn" | "raw"
 
 # If non-empty, only these labels are plotted. In compare mode, only labels
 # present in LABEL_FILTER *and* both datasets are shown.
@@ -120,6 +125,44 @@ def _read_binary(path: Path, num_samples: int, num_features: int) -> np.ndarray:
     return np.frombuffer(raw[:expected_bytes], dtype=np.float32).reshape(
         num_samples, num_features
     )
+
+
+def _count_lines(path: Path) -> int:
+    """Return the number of non-empty lines in a text file."""
+    with open(path, "r", encoding="utf-8") as f:
+        return sum(1 for line in f if line.strip())
+
+
+def load_raw_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, List[str]]:
+    """Load data_x.bin or data_y.bin with labels from metadata.txt.
+
+    metadata.txt format (comma-separated):
+      row 0: num_input_features, label_0, label_1, ...
+      row 1: num_output_features, label_0, label_1, ...
+
+    Sample count is derived from sequences_mann.txt (one non-empty line per sample).
+    """
+    d = Path(directory)
+    with open(d / "metadata.txt", "r", encoding="utf-8") as f:
+        lines = [l.strip() for l in f if l.strip()]
+
+    row_idx = 0 if data_type == "input" else 1
+    parts = lines[row_idx].split(",")
+    num_features = int(parts[0])
+    labels = [p.strip() for p in parts[1 : num_features + 1]]
+
+    num_samples = _count_lines(d / "sequences_mann.txt")
+    print(f"  [{data_type}] Shape: {num_samples} samples × {num_features} features")
+
+    bin_name = "data_x.bin" if data_type == "input" else "data_y.bin"
+    data = _read_binary(d / bin_name, num_samples, num_features)
+
+    if len(labels) != num_features:
+        print(
+            f"  WARNING: metadata.txt has {len(labels)} labels "
+            f"but {num_features} features expected"
+        )
+    return data, labels
 
 
 def load_dataset(directory: str, data_type: str = "input") -> Tuple[np.ndarray, List[str]]:
@@ -258,8 +301,11 @@ if __name__ == "__main__":
     if COMPARE_MODE:
         print(f"Loading baseline  ({COMPARE_DATA_TYPE}): {BASELINE_DIR}")
         b_data, b_labels = load_dataset(BASELINE_DIR, COMPARE_DATA_TYPE)
-        print(f"Loading candidate ({COMPARE_DATA_TYPE}): {CANDIDATE_DIR}")
-        c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
+        print(f"Loading candidate ({COMPARE_DATA_TYPE}) [{CANDIDATE_FORMAT}]: {CANDIDATE_DIR}")
+        if CANDIDATE_FORMAT == "raw":
+            c_data, c_labels = load_raw_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
+        else:
+            c_data, c_labels = load_dataset(CANDIDATE_DIR, COMPARE_DATA_TYPE)
         plot_compare_distributions(b_data, b_labels, c_data, c_labels, LABEL_FILTER, BINS)
     else:
         if DATA_TYPE not in ("input", "output"):

--- a/python/scripts/gnn_distribution_check.py
+++ b/python/scripts/gnn_distribution_check.py
@@ -1,0 +1,201 @@
+"""
+GNN Distribution Check
+
+Programmatically checks whether candidate (inference) data falls within the
+training (baseline) data distribution for every input and output feature.
+
+3-tier classification per feature (percentile-based):
+  WITHIN     — candidate value in baseline [p1, p99]
+  BORDERLINE — candidate value in baseline [p0.1, p99.9] but outside [p1, p99]
+  OUTSIDE    — candidate value outside baseline [p0.1, p99.9]
+
+Reports per-feature pass/borderline/fail rates and an overall verdict.
+Exit code: 0 = pass, 1 = any feature failing.
+"""
+
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import numpy as np
+
+from gnn_data_distribution import (
+    load_dataset,
+    load_raw_dataset,
+    _candidate_multiplier,
+)
+
+# -- Config -------------------------------------------------------------------
+
+BASELINE_DIR  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Data"
+CANDIDATE_DIR = r"D:\anim-ws\MANN Eval Scenes\infernece-data-7x1m"
+CANDIDATE_FORMAT = "gnn"  # "gnn" | "raw"
+
+CHECK_TYPES: List[str] = ["input", "output"]  # which data types to check
+
+INNER_PERCENTILES = (1, 99)      # comfortable range
+OUTER_PERCENTILES = (0.1, 99.9)  # plausible range
+FLAG_THRESHOLD    = 5.0           # % outside to flag a feature as FAILING
+
+# Scale multipliers for candidate pos/vel features (unit conversion).
+CANDIDATE_POS_MULTIPLIER = 1.0
+CANDIDATE_VEL_MULTIPLIER = 1.0
+
+# If non-empty, only check these labels. None = check all shared labels.
+LABEL_FILTER: Optional[List[str]] = None
+
+# -- Implementation -----------------------------------------------------------
+
+
+@dataclass
+class FeatureResult:
+    index: int
+    label: str
+    pct_within: float
+    pct_borderline: float
+    pct_outside: float
+
+
+def compute_bounds(
+    data: np.ndarray,
+    inner_pct: Tuple[float, float],
+    outer_pct: Tuple[float, float],
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+    """Compute per-feature percentile bounds from baseline data.
+
+    Returns (lo_inner, hi_inner, lo_outer, hi_outer), each shape (num_features,).
+    """
+    lo_inner = np.percentile(data, inner_pct[0], axis=0)
+    hi_inner = np.percentile(data, inner_pct[1], axis=0)
+    lo_outer = np.percentile(data, outer_pct[0], axis=0)
+    hi_outer = np.percentile(data, outer_pct[1], axis=0)
+    return lo_inner, hi_inner, lo_outer, hi_outer
+
+
+def classify_features(
+    baseline: np.ndarray,
+    candidate: np.ndarray,
+    labels: List[str],
+    label_indices_b: dict,
+    label_indices_c: dict,
+) -> List[FeatureResult]:
+    """Classify every shared feature into 3 tiers.
+
+    Returns a list of FeatureResult, one per shared label.
+    """
+    lo_in, hi_in, lo_out, hi_out = compute_bounds(
+        baseline, INNER_PERCENTILES, OUTER_PERCENTILES
+    )
+
+    results: List[FeatureResult] = []
+    n_samples = candidate.shape[0]
+
+    for lbl in labels:
+        bi = label_indices_b[lbl]
+        ci = label_indices_c[lbl]
+
+        m = _candidate_multiplier(lbl)
+        c_vals = candidate[:, ci] * m
+
+        within = np.sum((c_vals >= lo_in[bi]) & (c_vals <= hi_in[bi]))
+        in_outer = np.sum(
+            ((c_vals >= lo_out[bi]) & (c_vals < lo_in[bi]))
+            | ((c_vals > hi_in[bi]) & (c_vals <= hi_out[bi]))
+        )
+        outside = n_samples - within - in_outer
+
+        results.append(FeatureResult(
+            index=bi,
+            label=lbl,
+            pct_within=100.0 * within / n_samples,
+            pct_borderline=100.0 * in_outer / n_samples,
+            pct_outside=100.0 * outside / n_samples,
+        ))
+
+    return results
+
+
+def print_report(results: List[FeatureResult], data_type: str) -> int:
+    """Print a formatted report. Returns count of failing features."""
+    failing = [r for r in results if r.pct_outside >= FLAG_THRESHOLD]
+    borderline = [r for r in results if 0 < r.pct_outside < FLAG_THRESHOLD]
+    passing = [r for r in results if r.pct_outside == 0]
+
+    header = f"{data_type.upper()} CHECK ({len(results)} features)"
+    print(f"\n{'=' * 60}")
+    print(f"  {header}")
+    print(f"{'=' * 60}")
+    print(f"  + {len(passing)} features fully within distribution")
+    print(f"  ~ {len(borderline)} features borderline (< {FLAG_THRESHOLD}% outside)")
+    print(f"  X {len(failing)} features FAILING (>= {FLAG_THRESHOLD}% outside)")
+
+    if failing:
+        print(f"\n  FAILING features:")
+        for r in sorted(failing, key=lambda r: -r.pct_outside):
+            print(
+                f"    [{r.index:>4}] {r.label:<30s} "
+                f"-- {r.pct_outside:5.1f}% outside, {r.pct_borderline:5.1f}% borderline"
+            )
+
+    if borderline:
+        print(f"\n  BORDERLINE features:")
+        for r in sorted(borderline, key=lambda r: -r.pct_outside):
+            print(
+                f"    [{r.index:>4}] {r.label:<30s} "
+                f"-- {r.pct_outside:5.1f}% outside, {r.pct_borderline:5.1f}% borderline"
+            )
+
+    return len(failing)
+
+
+def resolve_shared_labels(
+    b_labels: List[str],
+    c_labels: List[str],
+    label_filter: Optional[List[str]],
+) -> Tuple[List[str], dict, dict]:
+    """Find shared labels, apply filter, return (labels, b_idx_map, c_idx_map)."""
+    b_idx = {lbl: i for i, lbl in enumerate(b_labels)}
+    c_idx = {lbl: i for i, lbl in enumerate(c_labels)}
+    shared = [lbl for lbl in b_labels if lbl in c_idx]
+
+    if label_filter:
+        missing = [lbl for lbl in label_filter if lbl not in b_idx or lbl not in c_idx]
+        if missing:
+            print(f"WARNING: labels not in both datasets: {missing}")
+        shared = [lbl for lbl in label_filter if lbl in b_idx and lbl in c_idx]
+
+    return shared, b_idx, c_idx
+
+
+# -- Main --------------------------------------------------------------------
+
+if __name__ == "__main__":
+    total_failing = 0
+
+    for dtype in CHECK_TYPES:
+        print(f"\nLoading baseline ({dtype}): {BASELINE_DIR}")
+        b_data, b_labels = load_dataset(BASELINE_DIR, dtype)
+
+        print(f"Loading candidate ({dtype}) [{CANDIDATE_FORMAT}]: {CANDIDATE_DIR}")
+        if CANDIDATE_FORMAT == "raw":
+            c_data, c_labels = load_raw_dataset(CANDIDATE_DIR, dtype)
+        else:
+            c_data, c_labels = load_dataset(CANDIDATE_DIR, dtype)
+
+        shared, b_idx, c_idx = resolve_shared_labels(b_labels, c_labels, LABEL_FILTER)
+        if not shared:
+            print(f"ERROR: no shared labels for {dtype}. Skipping.")
+            continue
+
+        results = classify_features(b_data, c_data, shared, b_idx, c_idx)
+        total_failing += print_report(results, dtype)
+
+    print(f"\n{'=' * 60}")
+    if total_failing:
+        print(f"  OVERALL: FAIL ({total_failing} feature(s) outside distribution)")
+    else:
+        print(f"  OVERALL: PASS")
+    print(f"{'=' * 60}\n")
+
+    sys.exit(1 if total_failing else 0)

--- a/python/scripts/gnn_inference.py
+++ b/python/scripts/gnn_inference.py
@@ -1,0 +1,975 @@
+"""
+GNN ONNX Inference Script
+
+Loads an ONNX-exported GNN model and runs inference on GNN Input.bin data,
+then compares model predictions against ground-truth Output.bin.
+
+Key facts:
+  - Normalization is baked into the ONNX model (Xnorm/Ynorm as nn.Parameter,
+    exported with export_params=True).  Pass raw Input.bin floats directly.
+  - gating_indices / main_indices are also baked in as constants.
+  - Separate ONNX files are required for baseline (559 features) and candidate
+    (530 features) because the input dimensions differ.
+  - "Target"    = Output.bin ground truth
+  - "Inference" = ONNX model prediction for the same input row
+
+Output label names (from OutputLabels.txt) are used for all config labels —
+NOT the input labels used in analyze_gnn_data.py.
+
+Modes:
+  "coordinates"           : 3 plots — baseline target vs inference, candidate
+                            target vs inference, per-frame position error.
+  "baseline_coordinates"  : 2 plots — baseline target vs inference + error.
+  "candidate_coordinates" : 2 plots — candidate target vs inference + error.
+  "speed"                 : 3 plots — baseline target vs inference speed,
+                            candidate target vs inference speed, speed error.
+
+Dependency: pip install onnxruntime
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import onnxruntime as ort
+
+# ── Config ────────────────────────────────────────────────────────────────────
+
+# Data directories (same as analyze_gnn_data.py)
+BASELINE_DIR  = r"D:\anim-ws\survivor-experiments\survivor-1\baseline\GNN Data"
+CANDIDATE_DIR = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN data"
+# CANDIDATE_DIR = r"D:\anim-ws\survivor-experiments\PR50-30pae-150gnn-nomirror-survivor25\GNN Data"
+
+# ONNX model paths — separate files because input dims differ (559 vs 530)
+BASELINE_ONNX_PATH  = r"D:\anim-ws\quad-experiments\quadruped-run-10\e2509_20260225_0\GNN\Training\150.onnx"
+CANDIDATE_ONNX_PATH = r"D:\anim-ws\quad-experiments\quadruped-run-7\GNN training\r7-unity-nomirror-150.onnx"
+# CANDIDATE_ONNX_PATH = r"D:\anim-ws\survivor-experiments\PR50-30pae-150gnn-nomirror-survivor25\GNN Training\150.onnx"
+
+MODE = "phase"  # "coordinates" | "baseline_coordinates" | "candidate_coordinates"
+                      # "speed" | "candidate_speed" | "phase" | "input_phase"
+
+BASELINE_SLICE  = (0, 1000)   # (start, end) rows from Input/Output.bin, or None
+CANDIDATE_SLICE = (0, 1000)
+
+# Scale applied to baseline OUTPUT positions before plotting (normalised → metres)
+BASELINE_COORD_SCALE = 1.0
+
+# ── Coordinate mode config ────────────────────────────────────────────────────
+# Labels must be OUTPUT label names (from OutputLabels.txt).
+# Baseline output has trajectory frames 8-13;  "TrajectoryPosition10X/Z" is
+# the midpoint.  Candidate output prefixes positions with "out_".
+# BASELINE_X_LABEL  = "TrajectoryPosition8X"
+# BASELINE_Y_LABEL  = "TrajectoryPosition8Z"
+BASELINE_X_LABEL  = "out_root_pos_x_7"
+BASELINE_Y_LABEL  = "out_root_pos_y_7"
+CANDIDATE_X_LABEL = "out_root_pos_x_7"
+CANDIDATE_Y_LABEL = "out_root_pos_y_7"
+
+# ── Speed mode config ──────────────────────────────────────────────────────────
+# Use single-column output labels that represent a speed-like scalar.
+# Baseline: RootVelocityX is the only single-axis root speed in the output.
+# Candidate: out_root_speed_7 is an explicit scalar speed prediction.
+# BASELINE_SPEED_LABEL  = "Actions8-3"
+BASELINE_SPEED_LABEL  = "out_root_speed_7"
+CANDIDATE_SPEED_LABEL = "out_root_speed_7"
+
+# ── Phase config ──────────────────────────────────────────────────────────────
+# Model training origin — controls output phase vector reordering.
+# Unity:    interleaved (x, y, amp, freq) per channel per key
+# AnimHost: grouped     [all phase2D | all amp | all freq] per key
+BASELINE_MODEL_ORIGIN  = "animhost"   # "unity" | "animhost"
+CANDIDATE_MODEL_ORIGIN = "animhost"
+
+N_PHASE_CH          = 5
+N_INPUT_PHASE_KEYS  = 13
+N_OUTPUT_PHASE_KEYS = 7
+
+PHASE_INPUT_PREFIX  = "PhaseSpace-"
+PHASE_OUTPUT_PREFIX = "PhaseUpdate-"
+
+BINS          = 100
+_MAX_SCATTER  = 20_000   # max points per series for scatter plots
+
+# Distribution check thresholds (same semantics as gnn_distribution_check.py)
+PHASE_INNER_PCT = (1, 99)
+PHASE_OUTER_PCT = (0.1, 99.9)
+PHASE_FAIL_THR  = 5.0  # % outside to flag as FAILING
+
+# ── I/O helpers (mirrors analyze_gnn_data.py) ─────────────────────────────────
+
+
+def _read_shape(directory: Path) -> tuple[int, int]:
+    text = (directory / "InputShape.txt").read_text(encoding="utf-8")
+    lines = text.strip().splitlines()
+    return int(lines[0]), int(lines[1])
+
+
+def _read_output_shape(directory: Path) -> tuple[int, int]:
+    text = (directory / "OutputShape.txt").read_text(encoding="utf-8")
+    lines = text.strip().splitlines()
+    return int(lines[0]), int(lines[1])
+
+
+def _read_labels(path: Path) -> list[str]:
+    labels: list[str] = []
+    with open(path, "r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            label = line.split("]", 1)[1].strip() if line.startswith("[") else line
+            labels.append(label)
+    return labels
+
+
+def _read_binary(path: Path, num_samples: int, num_features: int) -> np.ndarray:
+    expected = num_samples * num_features * 4
+    raw = path.read_bytes()
+    if len(raw) < expected:
+        raise EOFError(
+            f"{path.name} too small: expected {expected} bytes "
+            f"({num_samples}×{num_features}×4), got {len(raw)}"
+        )
+    return np.frombuffer(raw[:expected], dtype=np.float32).reshape(num_samples, num_features)
+
+
+def _label_to_col(labels: list[str], name: str) -> int:
+    for i, lbl in enumerate(labels):
+        if lbl == name:
+            return i
+    raise ValueError(
+        f"Label '{name}' not found. Available labels:\n"
+        + "\n".join(f"  [{i}] {l}" for i, l in enumerate(labels))
+    )
+
+
+def load_input(directory: str) -> tuple[np.ndarray, list[str]]:
+    d = Path(directory)
+    n, f = _read_shape(d)
+    print(f"  Input  shape: {n} samples × {f} features")
+    data = _read_binary(d / "Input.bin", n, f)
+    labels = _read_labels(d / "InputLabels.txt")
+    return data, labels
+
+
+def load_output(directory: str) -> tuple[np.ndarray, list[str]]:
+    d = Path(directory)
+    n, f = _read_output_shape(d)
+    print(f"  Output shape: {n} samples × {f} features")
+    data = _read_binary(d / "Output.bin", n, f)
+    labels = _read_labels(d / "OutputLabels.txt")
+    return data, labels
+
+
+# ── ONNX inference ─────────────────────────────────────────────────────────────
+
+
+def run_inference(onnx_path: str, input_data: np.ndarray) -> np.ndarray:
+    """Run ONNX model on input_data (N, in_features) → (N, out_features).
+
+    Normalization is baked into the model — pass raw Input.bin floats.
+    Output name "Y" contains the motion predictions; "W" (gating weights)
+    is ignored here.
+    """
+    sess = ort.InferenceSession(onnx_path, providers=["CPUExecutionProvider"])
+    in_name  = sess.get_inputs()[0].name   # "X"
+    out_name = "Y"
+
+    # Verify input feature count
+    expected_in = sess.get_inputs()[0].shape[1]
+    if expected_in is not None and expected_in != input_data.shape[1]:
+        raise ValueError(
+            f"ONNX model expects {expected_in} input features but "
+            f"data has {input_data.shape[1]}.  Wrong ONNX file for this dataset?"
+        )
+
+    print(f"  Running ONNX inference on {len(input_data)} frames …", end="", flush=True)
+    x = input_data.astype(np.float32)
+    try:
+        # Attempt batch inference first (faster)
+        result = sess.run([out_name], {in_name: x})[0]
+    except Exception:
+        # Fall back to row-by-row if batch dim is fixed at 1
+        rows = [
+            sess.run([out_name], {in_name: x[i : i + 1]})[0][0]
+            for i in range(len(x))
+        ]
+        result = np.array(rows, dtype=np.float32)
+    print(f" done → shape {result.shape}")
+    return result
+
+
+# ── Shared dataset pair loader ─────────────────────────────────────────────────
+
+
+def _load_pair(
+    directory: str,
+    onnx_path: str,
+    row_slice: tuple[int, int] | None,
+    tag: str,
+) -> tuple[np.ndarray, np.ndarray, list[str]]:
+    """Load input+output, slice, run inference.
+
+    Returns (target_data, inference_data, output_labels).
+    """
+    print(f"\nLoading {tag}: {directory}")
+    in_data,  _       = load_input(directory)
+    out_data, out_lbl = load_output(directory)
+
+    if row_slice is not None:
+        s, e = row_slice
+        in_data  = in_data[s:e]
+        out_data = out_data[s:e]
+        print(f"  Sliced [{s}:{e}] → {len(in_data)} frames")
+    else:
+        print(f"  {len(in_data)} frames (no slice)")
+
+    inference = run_inference(onnx_path, in_data)
+
+    if len(out_lbl) != inference.shape[1]:
+        print(
+            f"  WARNING: OutputLabels.txt has {len(out_lbl)} entries "
+            f"but inference produced {inference.shape[1]} features"
+        )
+
+    return out_data, inference, out_lbl
+
+
+# ── Plot helpers ───────────────────────────────────────────────────────────────
+
+
+def _plot_traj(
+    ax: plt.Axes,
+    x: np.ndarray,
+    y: np.ndarray,
+    label: str,
+    color: str,
+    linestyle: str = "-",
+) -> None:
+    ax.plot(x, y, "o", color=color, markersize=2, lw=0, alpha=0.5)
+    ax.plot(x, y, color=color, lw=0.8, alpha=0.8, linestyle=linestyle, label=label)
+    ax.plot(x[0], y[0], "s", color=color, markersize=7)
+    ax.plot(x[-1], y[-1], "^", color=color, markersize=7)
+
+
+def _pos_error(
+    tx: np.ndarray,
+    ty: np.ndarray,
+    ix: np.ndarray,
+    iy: np.ndarray,
+) -> np.ndarray:
+    return np.sqrt((tx - ix) ** 2 + (ty - iy) ** 2)
+
+
+# ── Phase helpers ─────────────────────────────────────────────────────────────
+
+
+def _find_label_range(labels: list[str], prefix: str) -> tuple[int, int]:
+    """Return (start, end) column indices for labels starting with *prefix*."""
+    indices = [i for i, l in enumerate(labels) if l.startswith(prefix)]
+    if not indices:
+        raise ValueError(
+            f"No labels starting with '{prefix}'. "
+            f"First 5: {labels[:5]} … ({len(labels)} total)"
+        )
+    return indices[0], indices[-1] + 1
+
+
+def _unity_to_animhost_output_perm() -> list[int]:
+    """Column permutation for ONE key: Unity interleaved → AnimHost grouped."""
+    n = N_PHASE_CH
+    perm: list[int] = []
+    for c in range(n):                       # phase2D
+        perm.extend([c * 4, c * 4 + 1])
+    for c in range(n):                       # amplitude
+        perm.append(c * 4 + 2)
+    for c in range(n):                       # frequency
+        perm.append(c * 4 + 3)
+    return perm
+
+
+def _reorder_output_phase(data: np.ndarray, origin: str) -> np.ndarray:
+    """Reorder output phase columns to AnimHost (canonical) layout.
+
+    data shape: (N, OUTPUT_PHASE_SIZE) — only the phase columns.
+    """
+    if origin == "animhost":
+        return data
+    vpk = N_PHASE_CH * 4
+    key_perm = _unity_to_animhost_output_perm()
+    full_perm: list[int] = []
+    for k in range(N_OUTPUT_PHASE_KEYS):
+        base = k * vpk
+        full_perm.extend(base + p for p in key_perm)
+    return data[:, full_perm]
+
+
+def _decode_output_phase(data: np.ndarray) -> np.ndarray:
+    """AnimHost-layout output phase (N, 140) → (N, 7, 5, 4).
+
+    Last dim = [x, y, amplitude, frequency].
+    Mirrors gnn_data_distribution.decode_output_phase.
+    """
+    N = data.shape[0]
+    blocks  = data.reshape(N, N_OUTPUT_PHASE_KEYS, N_PHASE_CH * 4)
+    phase2d = blocks[:, :, : N_PHASE_CH * 2].reshape(N, N_OUTPUT_PHASE_KEYS, N_PHASE_CH, 2)
+    amp     = blocks[:, :, N_PHASE_CH * 2 : N_PHASE_CH * 3][..., np.newaxis]
+    freq    = blocks[:, :, N_PHASE_CH * 3 :][..., np.newaxis]
+    return np.concatenate([phase2d, amp, freq], axis=-1)
+
+
+def _decode_input_phase(data: np.ndarray) -> np.ndarray:
+    """Input phase (N, 130) → (N, 13, 5, 2)  last dim = [x, y]."""
+    return data.reshape(data.shape[0], N_INPUT_PHASE_KEYS, N_PHASE_CH, 2)
+
+
+def _pct_check(
+    baseline_vals: np.ndarray,
+    candidate_vals: np.ndarray,
+) -> tuple[float, float, float]:
+    """Percentile-based distribution check (like gnn_distribution_check.py).
+
+    Returns (pct_within, pct_borderline, pct_outside).
+    """
+    lo_in  = np.percentile(baseline_vals, PHASE_INNER_PCT[0])
+    hi_in  = np.percentile(baseline_vals, PHASE_INNER_PCT[1])
+    lo_out = np.percentile(baseline_vals, PHASE_OUTER_PCT[0])
+    hi_out = np.percentile(baseline_vals, PHASE_OUTER_PCT[1])
+
+    n = len(candidate_vals)
+    within = np.sum((candidate_vals >= lo_in) & (candidate_vals <= hi_in))
+    in_outer = np.sum(
+        ((candidate_vals >= lo_out) & (candidate_vals < lo_in))
+        | ((candidate_vals > hi_in) & (candidate_vals <= hi_out))
+    )
+    outside = n - within - in_outer
+    return 100.0 * within / n, 100.0 * in_outer / n, 100.0 * outside / n
+
+
+def _subsample_xy(
+    x: np.ndarray, y: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    if len(x) > _MAX_SCATTER:
+        idx = np.random.default_rng(42).choice(len(x), _MAX_SCATTER, replace=False)
+        return x[idx], y[idx]
+    return x, y
+
+
+def _flat_ch(arr: np.ndarray, ch: int) -> np.ndarray:
+    """Flatten (N, K, 5[, ...]) → 1-D for channel *ch*."""
+    return arr[:, :, ch].ravel()
+
+
+# ── Phase plot helpers (mirrors gnn_data_distribution.py) ─────────────────────
+
+
+def _plot_phase_scatter(
+    a_xy: np.ndarray,
+    b_xy: np.ndarray,
+    title: str,
+    label_a: str = "target",
+    label_b: str = "inference",
+) -> None:
+    """2-D scatter per channel.  a_xy, b_xy: (N, K, 5, 2)."""
+    fig, axes = plt.subplots(1, N_PHASE_CH, figsize=(20, 4))
+    fig.suptitle(title)
+    for ch, ax in enumerate(axes):
+        ax1, ay1 = _subsample_xy(a_xy[:, :, ch, 0].ravel(), a_xy[:, :, ch, 1].ravel())
+        bx1, by1 = _subsample_xy(b_xy[:, :, ch, 0].ravel(), b_xy[:, :, ch, 1].ravel())
+        ax.scatter(ax1, ay1, s=1, alpha=0.2, color="tab:blue",   label=label_a, rasterized=True)
+        ax.scatter(bx1, by1, s=1, alpha=0.2, color="tab:orange", label=label_b, rasterized=True)
+        if ch == 0:
+            ax.legend(fontsize=7, markerscale=5)
+        ax.set_aspect("equal")
+        ax.axhline(0, color="k", lw=0.4, alpha=0.4)
+        ax.axvline(0, color="k", lw=0.4, alpha=0.4)
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("x", fontsize=8); ax.set_ylabel("y", fontsize=8)
+        ax.grid(True, alpha=0.2)
+    plt.tight_layout()
+
+
+def _plot_phase_polar(
+    a_xy: np.ndarray,
+    b_xy: np.ndarray,
+    title: str,
+    label_a: str = "target",
+    label_b: str = "inference",
+) -> None:
+    """Rose (polar histogram) of phase angle per channel.  a_xy, b_xy: (N, K, 5, 2)."""
+    N_BINS_ = 36
+    edges   = np.linspace(0, 2 * np.pi, N_BINS_ + 1)
+    width   = 2 * np.pi / N_BINS_
+    centers = (edges[:-1] + edges[1:]) / 2
+
+    fig, axes = plt.subplots(1, N_PHASE_CH, figsize=(20, 4),
+                             subplot_kw={"projection": "polar"})
+    fig.suptitle(title)
+    for ch, ax in enumerate(axes):
+        a_theta = np.arctan2(a_xy[:, :, ch, 1].ravel(), a_xy[:, :, ch, 0].ravel()) % (2 * np.pi)
+        b_theta = np.arctan2(b_xy[:, :, ch, 1].ravel(), b_xy[:, :, ch, 0].ravel()) % (2 * np.pi)
+        a_cnt, _ = np.histogram(a_theta, bins=edges)
+        b_cnt, _ = np.histogram(b_theta, bins=edges)
+        a_cnt = a_cnt / max(a_cnt.max(), 1)
+        b_cnt = b_cnt / max(b_cnt.max(), 1)
+        ax.bar(centers,                a_cnt, width=width * 0.45, color="tab:blue",   alpha=0.65, align="center", label=label_a)
+        ax.bar(centers + width * 0.45, b_cnt, width=width * 0.45, color="tab:orange", alpha=0.65, align="center", label=label_b)
+        ax.set_title(f"Ch {ch + 1}", fontsize=9, pad=10)
+        ax.set_yticks([])
+    plt.tight_layout()
+
+
+def _plot_phase_amplitude(
+    a_r: np.ndarray,
+    b_r: np.ndarray,
+    title: str,
+    label_a: str = "target",
+    label_b: str = "inference",
+) -> None:
+    """Amplitude histogram per channel.  a_r, b_r: (N, K, 5)."""
+    fig, axes = plt.subplots(1, N_PHASE_CH, figsize=(20, 4))
+    fig.suptitle(title)
+    for ch, ax in enumerate(axes):
+        ar = _flat_ch(a_r, ch)
+        br = _flat_ch(b_r, ch)
+        lo = min(ar.min(), br.min())
+        hi = max(ar.max(), br.max())
+        bins = np.linspace(lo, hi, BINS + 1)
+        ax.hist(ar, bins=bins, color="tab:blue",   alpha=0.55, density=True, label=label_a)
+        ax.hist(br, bins=bins, color="tab:orange", alpha=0.55, density=True, label=label_b)
+        if ch == 0:
+            ax.legend(fontsize=7)
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("amplitude", fontsize=8); ax.set_ylabel("density", fontsize=8)
+        ax.grid(True, alpha=0.25)
+    plt.tight_layout()
+
+
+def _plot_phase_frequency(
+    a_freq: np.ndarray,
+    b_freq: np.ndarray,
+    title: str,
+    label_a: str = "target",
+    label_b: str = "inference",
+) -> None:
+    """Frequency histogram per channel.  a_freq, b_freq: (N, K, 5)."""
+    fig, axes = plt.subplots(1, N_PHASE_CH, figsize=(20, 4))
+    fig.suptitle(title)
+    for ch, ax in enumerate(axes):
+        af = _flat_ch(a_freq, ch)
+        bf = _flat_ch(b_freq, ch)
+        lo = min(af.min(), bf.min())
+        hi = max(af.max(), bf.max())
+        bins = np.linspace(lo, hi, BINS + 1)
+        ax.hist(af, bins=bins, color="tab:blue",   alpha=0.55, density=True, label=label_a)
+        ax.hist(bf, bins=bins, color="tab:orange", alpha=0.55, density=True, label=label_b)
+        if ch == 0:
+            ax.legend(fontsize=7)
+        ax.set_title(f"Ch {ch + 1}", fontsize=9)
+        ax.set_xlabel("frequency", fontsize=8); ax.set_ylabel("density", fontsize=8)
+        ax.grid(True, alpha=0.25)
+    plt.tight_layout()
+
+
+def _plot_phase_temporal(
+    a_ph: np.ndarray,
+    b_ph: np.ndarray,
+    title: str,
+    label_a: str = "baseline",
+    label_b: str = "candidate",
+) -> None:
+    """Heatmap of mean amplitude over (keys x channels).  Input phase only.
+
+    a_ph, b_ph: (N, 13, 5, 2).
+    """
+    a_r = np.sqrt((a_ph ** 2).sum(-1)).mean(0)   # (13, 5)
+    b_r = np.sqrt((b_ph ** 2).sum(-1)).mean(0)
+    vmin = min(a_r.min(), b_r.min())
+    vmax = max(a_r.max(), b_r.max())
+
+    fig, (ax_a, ax_b) = plt.subplots(1, 2, figsize=(14, 4))
+    fig.suptitle(title)
+    for ax, mat, lbl in [(ax_a, a_r, label_a), (ax_b, b_r, label_b)]:
+        im = ax.imshow(mat.T, aspect="auto", origin="lower", vmin=vmin, vmax=vmax, cmap="viridis")
+        ax.set_title(lbl, fontsize=9)
+        ax.set_xlabel("key offset  (0 = far past … 12 = far future)", fontsize=8)
+        ax.set_ylabel("channel", fontsize=8)
+        ax.set_yticks(range(N_PHASE_CH))
+        ax.set_yticklabels([f"Ch {c + 1}" for c in range(N_PHASE_CH)], fontsize=8)
+        fig.colorbar(im, ax=ax, label="mean amplitude")
+    plt.tight_layout()
+
+
+# ── Modes ─────────────────────────────────────────────────────────────────────
+
+
+def mode_coordinates(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_onnx: str,
+    candidate_onnx: str,
+    baseline_x_label: str,
+    baseline_y_label: str,
+    candidate_x_label: str,
+    candidate_y_label: str,
+    baseline_coord_scale: float = 100.0,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """3-subplot figure: baseline traj, candidate traj, per-frame position error."""
+    b_tgt, b_inf, b_lbl = _load_pair(baseline_dir,  baseline_onnx,  baseline_slice,  "baseline")
+    c_tgt, c_inf, c_lbl = _load_pair(candidate_dir, candidate_onnx, candidate_slice, "candidate")
+
+    bx_col = _label_to_col(b_lbl, baseline_x_label)
+    by_col = _label_to_col(b_lbl, baseline_y_label)
+    cx_col = _label_to_col(c_lbl, candidate_x_label)
+    cy_col = _label_to_col(c_lbl, candidate_y_label)
+
+    btx = b_tgt[:, bx_col] * baseline_coord_scale
+    bty = b_tgt[:, by_col] * baseline_coord_scale
+    bix = b_inf[:, bx_col] * baseline_coord_scale
+    biy = b_inf[:, by_col] * baseline_coord_scale
+
+    ctx = c_tgt[:, cx_col]
+    cty = c_tgt[:, cy_col]
+    cix = c_inf[:, cx_col]
+    ciy = c_inf[:, cy_col]
+
+    b_err = _pos_error(btx, bty, bix, biy)
+    c_err = _pos_error(ctx, cty, cix, ciy)
+
+    print(f"\n── Coordinate Stats ─────────────────────────────────────────")
+    print(f"  Baseline  pos error: mean {b_err.mean():.4f}  max {b_err.max():.4f}")
+    print(f"  Candidate pos error: mean {c_err.mean():.4f}  max {c_err.max():.4f}")
+
+    fig, axes = plt.subplots(1, 3, figsize=(21, 7))
+    fig.suptitle("GNN Inference — 2D Trajectory: Target vs Inference", fontsize=12)
+
+    ax = axes[0]
+    _plot_traj(ax, btx, bty, "target",    "tab:blue",   "-")
+    _plot_traj(ax, bix, biy, "inference", "tab:orange", "--")
+    ax.set_title(f"Baseline  ({baseline_x_label})", fontsize=9, loc="left")
+    ax.set_xlabel("X (m)"); ax.set_ylabel("Y (m)")
+    ax.set_aspect("equal"); ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[1]
+    _plot_traj(ax, ctx, cty, "target",    "tab:blue",   "-")
+    _plot_traj(ax, cix, ciy, "inference", "tab:orange", "--")
+    ax.set_title(f"Candidate  ({candidate_x_label})", fontsize=9, loc="left")
+    ax.set_xlabel("X (m)"); ax.set_ylabel("Y (m)")
+    ax.set_aspect("equal"); ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[2]
+    ax.plot(b_err, color="tab:blue",   lw=0.8, alpha=0.85,
+            label=f"baseline  (mean={b_err.mean():.3f})")
+    ax.plot(c_err, color="tab:orange", lw=0.8, alpha=0.85,
+            label=f"candidate (mean={c_err.mean():.3f})")
+    ax.set_title("Position Error (Euclidean)", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Error (m)")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_baseline_coordinates(
+    baseline_dir: str,
+    baseline_onnx: str,
+    baseline_x_label: str,
+    baseline_y_label: str,
+    baseline_coord_scale: float = 100.0,
+    baseline_slice: tuple[int, int] | None = None,
+) -> None:
+    """2-subplot figure: baseline trajectory + per-frame error."""
+    b_tgt, b_inf, b_lbl = _load_pair(baseline_dir, baseline_onnx, baseline_slice, "baseline")
+
+    bx_col = _label_to_col(b_lbl, baseline_x_label)
+    by_col = _label_to_col(b_lbl, baseline_y_label)
+
+    btx = b_tgt[:, bx_col] * baseline_coord_scale
+    bty = b_tgt[:, by_col] * baseline_coord_scale
+    bix = b_inf[:, bx_col] * baseline_coord_scale
+    biy = b_inf[:, by_col] * baseline_coord_scale
+    b_err = _pos_error(btx, bty, bix, biy)
+
+    print(f"\n  Baseline pos error: mean {b_err.mean():.4f}  max {b_err.max():.4f}")
+
+    fig, axes = plt.subplots(1, 2, figsize=(16, 7))
+    fig.suptitle("GNN Inference — Baseline Trajectory: Target vs Inference", fontsize=12)
+
+    ax = axes[0]
+    _plot_traj(ax, btx, bty, "target",    "tab:blue",   "-")
+    _plot_traj(ax, bix, biy, "inference", "tab:orange", "--")
+    ax.set_title(f"Baseline  ({baseline_x_label})", fontsize=9, loc="left")
+    ax.set_xlabel("X (m)"); ax.set_ylabel("Y (m)")
+    ax.set_aspect("equal"); ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[1]
+    ax.plot(b_err, color="tab:blue", lw=0.8, alpha=0.85,
+            label=f"mean={b_err.mean():.3f}")
+    ax.set_title("Position Error (Euclidean)", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Error (m)")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_candidate_coordinates(
+    candidate_dir: str,
+    candidate_onnx: str,
+    candidate_x_label: str,
+    candidate_y_label: str,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """2-subplot figure: candidate trajectory + per-frame error."""
+    c_tgt, c_inf, c_lbl = _load_pair(candidate_dir, candidate_onnx, candidate_slice, "candidate")
+
+    cx_col = _label_to_col(c_lbl, candidate_x_label)
+    cy_col = _label_to_col(c_lbl, candidate_y_label)
+
+    ctx = c_tgt[:, cx_col]
+    cty = c_tgt[:, cy_col]
+    cix = c_inf[:, cx_col]
+    ciy = c_inf[:, cy_col]
+    c_err = _pos_error(ctx, cty, cix, ciy)
+
+    print(f"\n  Candidate pos error: mean {c_err.mean():.4f}  max {c_err.max():.4f}")
+
+    fig, axes = plt.subplots(1, 2, figsize=(16, 7))
+    fig.suptitle("GNN Inference — Candidate Trajectory: Target vs Inference", fontsize=12)
+
+    ax = axes[0]
+    _plot_traj(ax, ctx, cty, "target",    "tab:blue",   "-")
+    _plot_traj(ax, cix, ciy, "inference", "tab:orange", "--")
+    ax.set_title(f"Candidate  ({candidate_x_label})", fontsize=9, loc="left")
+    ax.set_xlabel("X (m)"); ax.set_ylabel("Y (m)")
+    ax.set_aspect("equal"); ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[1]
+    ax.plot(c_err, color="tab:orange", lw=0.8, alpha=0.85,
+            label=f"mean={c_err.mean():.3f}")
+    ax.set_title("Position Error (Euclidean)", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Error (m)")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_candidate_speed(
+    candidate_dir: str,
+    candidate_onnx: str,
+    candidate_speed_label: str,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """2-subplot figure: candidate speed target vs inference + error."""
+    c_tgt, c_inf, c_lbl = _load_pair(candidate_dir, candidate_onnx, candidate_slice, "candidate")
+
+    cs_col = _label_to_col(c_lbl, candidate_speed_label)
+    cts = c_tgt[:, cs_col]
+    cis = c_inf[:, cs_col]
+    c_err = np.abs(cts - cis)
+
+    print(f"\n── Candidate Speed Stats ────────────────────────────────────")
+    print(f"  Target  range [{cts.min():.4f}, {cts.max():.4f}]  mean {cts.mean():.4f}")
+    print(f"  Infer   range [{cis.min():.4f}, {cis.max():.4f}]  mean {cis.mean():.4f}")
+    print(f"  Error   mean {c_err.mean():.4f}  max {c_err.max():.4f}")
+
+    fig, axes = plt.subplots(1, 2, figsize=(14, 5))
+    fig.suptitle("GNN Inference — Candidate Speed: Target vs Inference", fontsize=12)
+
+    ax = axes[0]
+    ax.plot(cts, color="tab:blue",   lw=0.8, alpha=0.85, label="target")
+    ax.plot(cis, color="tab:orange", lw=0.8, alpha=0.85, label="inference", linestyle="--")
+    ax.set_title(f"Candidate  ({candidate_speed_label})", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Speed")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[1]
+    ax.plot(c_err, color="tab:orange", lw=0.8, alpha=0.85,
+            label=f"mean={c_err.mean():.4f}")
+    ax.set_title("Speed Error (|target − inference|)", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("|Error|")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def mode_speed(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_onnx: str,
+    candidate_onnx: str,
+    baseline_speed_label: str,
+    candidate_speed_label: str,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """3-subplot figure: baseline speed, candidate speed, speed error."""
+    b_tgt, b_inf, b_lbl = _load_pair(baseline_dir,  baseline_onnx,  baseline_slice,  "baseline")
+    c_tgt, c_inf, c_lbl = _load_pair(candidate_dir, candidate_onnx, candidate_slice, "candidate")
+
+    bs_col = _label_to_col(b_lbl, baseline_speed_label)
+    cs_col = _label_to_col(c_lbl, candidate_speed_label)
+
+    bts = b_tgt[:, bs_col]
+    bis = b_inf[:, bs_col]
+    cts = c_tgt[:, cs_col]
+    cis = c_inf[:, cs_col]
+
+    b_err = np.abs(bts - bis)
+    c_err = np.abs(cts - cis)
+
+    print(f"\n── Speed Stats ──────────────────────────────────────────────")
+    print(f"  Baseline  target  range [{bts.min():.4f}, {bts.max():.4f}]  mean {bts.mean():.4f}")
+    print(f"  Baseline  infer   range [{bis.min():.4f}, {bis.max():.4f}]  mean {bis.mean():.4f}")
+    print(f"  Candidate target  range [{cts.min():.4f}, {cts.max():.4f}]  mean {cts.mean():.4f}")
+    print(f"  Candidate infer   range [{cis.min():.4f}, {cis.max():.4f}]  mean {cis.mean():.4f}")
+
+    fig, axes = plt.subplots(1, 3, figsize=(21, 5))
+    fig.suptitle("GNN Inference — Speed: Target vs Inference", fontsize=12)
+
+    ax = axes[0]
+    ax.plot(bts, color="tab:blue",   lw=0.8, alpha=0.85, label="target")
+    ax.plot(bis, color="tab:orange", lw=0.8, alpha=0.85, label="inference", linestyle="--")
+    ax.set_title(f"Baseline  ({baseline_speed_label})", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Speed")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[1]
+    ax.plot(cts, color="tab:blue",   lw=0.8, alpha=0.85, label="target")
+    ax.plot(cis, color="tab:orange", lw=0.8, alpha=0.85, label="inference", linestyle="--")
+    ax.set_title(f"Candidate  ({candidate_speed_label})", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("Speed")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    ax = axes[2]
+    ax.plot(b_err, color="tab:blue",   lw=0.8, alpha=0.85,
+            label=f"baseline  (mean={b_err.mean():.4f})")
+    ax.plot(c_err, color="tab:orange", lw=0.8, alpha=0.85,
+            label=f"candidate (mean={c_err.mean():.4f})")
+    ax.set_title("Speed Error (|target − inference|)", fontsize=9, loc="left")
+    ax.set_xlabel("Frame"); ax.set_ylabel("|Error|")
+    ax.grid(True, alpha=0.25); ax.legend(fontsize=8)
+
+    plt.tight_layout()
+    plt.show()
+
+
+def _phase_plots_output(
+    tgt_ph: np.ndarray,
+    inf_ph: np.ndarray,
+    tag: str,
+) -> None:
+    """Produce the full gnn_data_distribution-style output phase plot set.
+
+    tgt_ph, inf_ph: (N, 7, 5, 4)  last dim = [x, y, amp, freq].
+    """
+    tgt_xy   = tgt_ph[..., :2]          # (N, 7, 5, 2)
+    inf_xy   = inf_ph[..., :2]
+    tgt_amp  = tgt_ph[..., 2]           # (N, 7, 5)
+    inf_amp  = inf_ph[..., 2]
+    tgt_freq = tgt_ph[..., 3]
+    inf_freq = inf_ph[..., 3]
+
+    _plot_phase_scatter(tgt_xy, inf_xy,
+                        f"Output Phase Scatter — {tag}")
+    _plot_phase_polar(tgt_xy, inf_xy,
+                      f"Output Phase Angle Distribution — {tag}")
+    _plot_phase_amplitude(tgt_amp, inf_amp,
+                          f"Output Phase Amplitude — {tag}")
+    _plot_phase_frequency(tgt_freq, inf_freq,
+                          f"Output Phase Frequency — {tag}")
+
+
+def _phase_plots_input(
+    b_ph: np.ndarray,
+    c_ph: np.ndarray,
+) -> None:
+    """Produce the full gnn_data_distribution-style input phase plot set.
+
+    b_ph, c_ph: (N, 13, 5, 2)  last dim = [x, y].
+    """
+    b_r = np.sqrt((b_ph ** 2).sum(-1))   # (N, 13, 5)
+    c_r = np.sqrt((c_ph ** 2).sum(-1))
+
+    _plot_phase_scatter(b_ph, c_ph,
+                        "Input Phase Scatter — Baseline vs Candidate",
+                        label_a="baseline", label_b="candidate")
+    _plot_phase_polar(b_ph, c_ph,
+                      "Input Phase Angle Distribution — Baseline vs Candidate",
+                      label_a="baseline", label_b="candidate")
+    _plot_phase_amplitude(b_r, c_r,
+                          "Input Phase Amplitude — Baseline vs Candidate",
+                          label_a="baseline", label_b="candidate")
+    _plot_phase_temporal(b_ph, c_ph,
+                         "Input Phase Temporal Amplitude — Baseline vs Candidate")
+
+
+def mode_phase(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_onnx: str,
+    candidate_onnx: str,
+    baseline_model_origin: str,
+    candidate_model_origin: str,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Output phase: target vs inference — same plots as gnn_data_distribution.
+
+    Produces scatter, polar, amplitude and frequency figures for each dataset.
+    Reorders output phase to canonical AnimHost layout when needed.
+    """
+    b_tgt, b_inf, b_lbl = _load_pair(baseline_dir, baseline_onnx, baseline_slice, "baseline")
+    c_tgt, c_inf, c_lbl = _load_pair(candidate_dir, candidate_onnx, candidate_slice, "candidate")
+
+    # Locate output phase columns
+    bs, be = _find_label_range(b_lbl, PHASE_OUTPUT_PREFIX)
+    cs, ce = _find_label_range(c_lbl, PHASE_OUTPUT_PREFIX)
+    print(f"  Baseline  output phase cols [{bs}:{be}] ({be - bs} features, {baseline_model_origin})")
+    print(f"  Candidate output phase cols [{cs}:{ce}] ({ce - cs} features, {candidate_model_origin})")
+
+    # Extract, reorder to canonical AnimHost layout, decode to (N, 7, 5, 4)
+    b_tgt_ph = _decode_output_phase(_reorder_output_phase(b_tgt[:, bs:be], baseline_model_origin))
+    b_inf_ph = _decode_output_phase(_reorder_output_phase(b_inf[:, bs:be], baseline_model_origin))
+    c_tgt_ph = _decode_output_phase(_reorder_output_phase(c_tgt[:, cs:ce], candidate_model_origin))
+    c_inf_ph = _decode_output_phase(_reorder_output_phase(c_inf[:, cs:ce], candidate_model_origin))
+
+    # Print per-component, per-channel error stats
+    print(f"\n── Output Phase Error (target vs inference) ─────────────────")
+    for name, idx_or_fn in [("phase2d", "xy"), ("amplitude", 2), ("frequency", 3)]:
+        if name == "phase2d":
+            b_e = np.sqrt(((b_tgt_ph[..., :2] - b_inf_ph[..., :2]) ** 2).sum(axis=-1))
+            c_e = np.sqrt(((c_tgt_ph[..., :2] - c_inf_ph[..., :2]) ** 2).sum(axis=-1))
+        else:
+            b_e = np.abs(b_tgt_ph[..., idx_or_fn] - b_inf_ph[..., idx_or_fn])
+            c_e = np.abs(c_tgt_ph[..., idx_or_fn] - c_inf_ph[..., idx_or_fn])
+        print(f"  {name:>10s}  baseline mean={b_e.mean():.4f}  candidate mean={c_e.mean():.4f}")
+        for ch in range(N_PHASE_CH):
+            print(f"    ch{ch}  baseline={b_e[:, :, ch].mean():.4f}  candidate={c_e[:, :, ch].mean():.4f}")
+
+    # Phase plots — 4 figures per dataset (scatter, polar, amplitude, frequency)
+    _phase_plots_output(b_tgt_ph, b_inf_ph, "Baseline: Target vs Inference")
+    _phase_plots_output(c_tgt_ph, c_inf_ph, "Candidate: Target vs Inference")
+    plt.show()
+
+
+def mode_input_phase(
+    baseline_dir: str,
+    candidate_dir: str,
+    baseline_slice: tuple[int, int] | None = None,
+    candidate_slice: tuple[int, int] | None = None,
+) -> None:
+    """Input phase distribution: baseline vs candidate.
+
+    Same plots as gnn_data_distribution INPUT_PHASE_MODE + COMPARE_MODE:
+    scatter, polar, amplitude histogram, temporal heatmap.
+    Also prints a percentile-based distribution check per channel.
+    No ONNX inference needed.
+    """
+    print("\nLoading baseline input …")
+    b_in, b_in_lbl = load_input(baseline_dir)
+    print("Loading candidate input …")
+    c_in, c_in_lbl = load_input(candidate_dir)
+
+    if baseline_slice is not None:
+        b_in = b_in[baseline_slice[0]:baseline_slice[1]]
+        print(f"  Baseline  sliced [{baseline_slice[0]}:{baseline_slice[1]}]")
+    if candidate_slice is not None:
+        c_in = c_in[candidate_slice[0]:candidate_slice[1]]
+        print(f"  Candidate sliced [{candidate_slice[0]}:{candidate_slice[1]}]")
+
+    # Locate input phase columns (layout is identical for Unity and AnimHost)
+    bs, be = _find_label_range(b_in_lbl, PHASE_INPUT_PREFIX)
+    cs, ce = _find_label_range(c_in_lbl, PHASE_INPUT_PREFIX)
+    print(f"  Baseline  input phase cols [{bs}:{be}] ({be - bs} features)")
+    print(f"  Candidate input phase cols [{cs}:{ce}] ({ce - cs} features)")
+
+    b_phase = _decode_input_phase(b_in[:, bs:be])  # (N, 13, 5, 2)
+    c_phase = _decode_input_phase(c_in[:, cs:ce])
+
+    # Percentile-based distribution check per channel
+    b_amp = np.sqrt((b_phase ** 2).sum(axis=-1))  # (N, 13, 5)
+    c_amp = np.sqrt((c_phase ** 2).sum(axis=-1))
+
+    n_fail = 0
+    print(f"\n── Input Phase Distribution Check ──────────────────────────")
+    print(f"  {'ch':>4s}  {'status':>4s}  {'within':>10s}  {'border':>10s}  {'outside':>10s}  "
+          f"{'baseline µ±σ':>16s}  {'candidate µ±σ':>16s}")
+    for ch in range(N_PHASE_CH):
+        b_vals = b_amp[:, :, ch].ravel()
+        c_vals = c_amp[:, :, ch].ravel()
+        within, border, outside = _pct_check(b_vals, c_vals)
+        status = "FAIL" if outside >= PHASE_FAIL_THR else ("WARN" if outside > 0 else "PASS")
+        if outside >= PHASE_FAIL_THR:
+            n_fail += 1
+        print(
+            f"  ch{ch}   {status:>4s}  {within:9.1f}%  {border:9.1f}%  {outside:9.1f}%  "
+            f"{b_vals.mean():7.3f}±{b_vals.std():<6.3f}  "
+            f"{c_vals.mean():7.3f}±{c_vals.std():<6.3f}"
+        )
+
+    print(f"\n  Input phase verdict: {'PASS' if n_fail == 0 else f'FAIL ({n_fail} feature(s))'}")
+
+    # Phase plots — scatter, polar, amplitude, temporal (4 figures)
+    _phase_plots_input(b_phase, c_phase)
+    plt.show()
+
+
+# ── Main ──────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    if MODE == "coordinates":
+        mode_coordinates(
+            BASELINE_DIR, CANDIDATE_DIR,
+            BASELINE_ONNX_PATH, CANDIDATE_ONNX_PATH,
+            BASELINE_X_LABEL, BASELINE_Y_LABEL,
+            CANDIDATE_X_LABEL, CANDIDATE_Y_LABEL,
+            BASELINE_COORD_SCALE,
+            BASELINE_SLICE, CANDIDATE_SLICE,
+        )
+    elif MODE == "baseline_coordinates":
+        mode_baseline_coordinates(
+            BASELINE_DIR, BASELINE_ONNX_PATH,
+            BASELINE_X_LABEL, BASELINE_Y_LABEL,
+            BASELINE_COORD_SCALE,
+            BASELINE_SLICE,
+        )
+    elif MODE == "candidate_coordinates":
+        mode_candidate_coordinates(
+            CANDIDATE_DIR, CANDIDATE_ONNX_PATH,
+            CANDIDATE_X_LABEL, CANDIDATE_Y_LABEL,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "speed":
+        mode_speed(
+            BASELINE_DIR, CANDIDATE_DIR,
+            BASELINE_ONNX_PATH, CANDIDATE_ONNX_PATH,
+            BASELINE_SPEED_LABEL, CANDIDATE_SPEED_LABEL,
+            BASELINE_SLICE, CANDIDATE_SLICE,
+        )
+    elif MODE == "candidate_speed":
+        mode_candidate_speed(
+            CANDIDATE_DIR, CANDIDATE_ONNX_PATH,
+            CANDIDATE_SPEED_LABEL,
+            CANDIDATE_SLICE,
+        )
+    elif MODE == "phase":
+        mode_phase(
+            BASELINE_DIR, CANDIDATE_DIR,
+            BASELINE_ONNX_PATH, CANDIDATE_ONNX_PATH,
+            BASELINE_MODEL_ORIGIN, CANDIDATE_MODEL_ORIGIN,
+            BASELINE_SLICE, CANDIDATE_SLICE,
+        )
+    elif MODE == "input_phase":
+        mode_input_phase(
+            BASELINE_DIR, CANDIDATE_DIR,
+            BASELINE_SLICE, CANDIDATE_SLICE,
+        )
+    else:
+        print(f"Unknown mode: {MODE!r}")


### PR DESCRIPTION
## Description
* Animation sender uses blender character skinnedMesh boneMapIDs (available for biped), falls back to skeletonObjIDs (qaudruped only)
* Option to export GNN Controller inference dataset
* Update VSCode search excludes to unblock search
* Scripts for analyzing GNN training data and open-loop inference of two runs (analyze_gnn_data.py, gnn_inference.py).
* Scripts for checking inference vs training input/output distributions (gnn_distribution_check.py, gnn_data_distribution.py). 

## Testing
- [x] Tested end to end for the latest quadruped and biped model